### PR TITLE
Update predefined CPU lists in the documents  

### DIFF
--- a/bochs/.bochsrc
+++ b/bochs/.bochsrc
@@ -137,6 +137,10 @@
 #  corei7_ivy_bridge_3770k    Intel(R) Core(TM) i7-3770K CPU (Ivy Bridge)
 #  corei7_haswell_4770        Intel(R) Core(TM) i7-4770 CPU (Haswell)
 #  broadwell_ult              Intel(R) Processor 5Y70 CPU (Broadwell)
+#  corei7_skylake_x           Intel(R) Core(TM) i7-7800X CPU (Skylake)
+#  corei3_cnl                 Intel(R) Core(TM) i3-8121U CPU (Cannonlake)
+#  corei7_icelake_u           QuadCore Intel Core i7-1065G7 (IceLake)
+#  tigerlake                  11th Gen Intel(R) Core(TM) i5-1135G7 (TigerLake)
 #
 #  COUNT:
 #    Set the number of processors:cores per processor:threads per core when

--- a/bochs/.bochsrc
+++ b/bochs/.bochsrc
@@ -41,14 +41,14 @@
 #=======================================================================
 # DISPLAY_LIBRARY
 #
-# The display library is the code that displays the Bochs VGA screen.  Bochs 
-# has a selection of about 10 different display library implementations for 
-# different platforms.  If you run configure with multiple --with-* options, 
+# The display library is the code that displays the Bochs VGA screen.  Bochs
+# has a selection of about 10 different display library implementations for
+# different platforms.  If you run configure with multiple --with-* options,
 # the display_library command lets you choose which one you want to run with.
 # If you do not write a display_library line, Bochs will choose a default for
 # you.
 #
-# The choices are: 
+# The choices are:
 #   x              use X windows interface, cross platform
 #   win32          use native win32 libraries
 #   carbon         use Carbon library (for MacOS X)
@@ -147,12 +147,12 @@
 #
 #  QUANTUM:
 #    Maximum amount of instructions allowed to execute by processor before
-#    returning control to another cpu. This option exists only in Bochs 
+#    returning control to another cpu. This option exists only in Bochs
 #    binary compiled with SMP support.
 #
 #  RESET_ON_TRIPLE_FAULT:
 #    Reset the CPU when triple fault occur (highly recommended) rather than
-#    PANIC. Remember that if you trying to continue after triple fault the 
+#    PANIC. Remember that if you trying to continue after triple fault the
 #    simulation will be completely bogus !
 #
 #  CPUID_LIMIT_WINNT:
@@ -179,7 +179,7 @@
 #    Measured IPS value will then be logged into your log file or shown
 #    in the status bar (if supported by the gui).
 #
-#    IPS is used to calibrate many time-dependent events within the bochs 
+#    IPS is used to calibrate many time-dependent events within the bochs
 #    simulation.  For example, changing IPS affects the frequency of VGA
 #    updates, the duration of time before a key starts to autorepeat, and
 #    the measurement of BogoMips and other benchmarks.
@@ -317,11 +317,11 @@ cpu: cpuid_limit_winnt=0
 #
 #  VENDOR_STRING:
 #    Set the CPUID vendor string returned by CPUID(0x0). This should be a
-#    twelve-character ASCII string.  
+#    twelve-character ASCII string.
 #
 #  BRAND_STRING:
-#    Set the CPUID vendor string returned by CPUID(0x80000002 .. 0x80000004).  
-#    This should be at most a forty-eight-character ASCII string.  
+#    Set the CPUID vendor string returned by CPUID(0x80000002 .. 0x80000004).
+#    This should be at most a forty-eight-character ASCII string.
 #
 #  LEVEL:
 #    Set emulated CPU level information returned by CPUID. Default value is
@@ -398,11 +398,11 @@ vgaromimage: file=$BXSHARE/VGABIOS-lgpl-latest
 
 #=======================================================================
 # OPTROMIMAGE[1-4]:
-# You may now load up to 4 optional ROM images. Be sure to use a 
+# You may now load up to 4 optional ROM images. Be sure to use a
 # read-only area, typically between C8000 and EFFFF. These optional
 # ROM images should not overwrite the rombios (located at
 # F0000-FFFFF) and the videobios (located at C0000-C7FFF).
-# Those ROM images will be initialized by the bios if they contain 
+# Those ROM images will be initialized by the bios if they contain
 # the right signature (0x55AA) and a valid checksum.
 # It can also be a convenient way to upload some arbitrary code/data
 # in the simulation, that can be retrieved by the boot loader
@@ -484,7 +484,7 @@ vgaromimage: file=$BXSHARE/VGABIOS-lgpl-latest
 #     characters to the keyboard controller. This leaves time for the
 #     guest os to deal with the flow of characters.  The ideal setting
 #     depends on how your operating system processes characters.  The
-#     default of 100000 usec (.1 seconds) was chosen because it works 
+#     default of 100000 usec (.1 seconds) was chosen because it works
 #     consistently in Windows.
 #     If your OS is losing characters during a paste, increase the paste
 #     delay until it stops losing characters.
@@ -567,7 +567,7 @@ mouse: enabled=0
 #  to AGP.
 #
 #  ADVOPTS:
-#  With the advanced PCI options it is possible to control the behaviour of the 
+#  With the advanced PCI options it is possible to control the behaviour of the
 #  PCI chipset. These options can be specified as comma-separated values.
 #  By default the "Bochs i440FX" chipset enables the ACPI and HPET devices, but
 #  original i440FX doesn't support them. The options 'noacpi' and 'nohpet' make
@@ -695,10 +695,10 @@ floppya: 1_44=/dev/fd0, status=inserted
 # ATA controller for hard disks and cdroms
 #
 # ata[0-3]: enabled=[0|1], ioaddr1=addr, ioaddr2=addr, irq=number
-# 
+#
 # These options enables up to 4 ata channels. For each channel
 # the two base io addresses and the irq must be specified.
-# 
+#
 # ata0 and ata1 are enabled by default with the values shown below
 #
 # Examples:
@@ -716,7 +716,7 @@ ata3: enabled=0, ioaddr1=0x168, ioaddr2=0x360, irq=9
 # ATA[0-3]-MASTER, ATA[0-3]-SLAVE
 #
 # This defines the type and characteristics of all attached ata devices:
-#   type=       type of attached device [disk|cdrom] 
+#   type=       type of attached device [disk|cdrom]
 #   mode=       only valid for disks [flat|concat|dll|sparse|vmware3|vmware4]
 #                                    [undoable|growing|volatile|vpc|vbox|vvfat]
 #   path=       path of the image / directory
@@ -733,11 +733,11 @@ ata3: enabled=0, ioaddr1=0x168, ioaddr2=0x360, irq=9
 # device.  To create a hard disk image, try running bximage.  It will help you
 # choose the size and then suggest a line that works with it.
 #
-# In UNIX it may be possible to use a raw device as a Bochs hard disk, 
+# In UNIX it may be possible to use a raw device as a Bochs hard disk,
 # but WE DON'T RECOMMEND IT.  In Windows there is no easy way.
 #
 # In windows, the drive letter + colon notation should be used for cdroms.
-# Depending on versions of windows and drivers, you may only be able to 
+# Depending on versions of windows and drivers, you may only be able to
 # access the "first" cdrom in the system.  On MacOSX, use path="drive"
 # to access the physical drive.
 #
@@ -769,7 +769,7 @@ ata0-master: type=disk, mode=flat, path="30M.sample"
 #ata0-slave: type=cdrom, path=D:, status=inserted
 #ata0-slave: type=cdrom, path=/dev/cdrom, status=inserted
 #ata0-slave: type=cdrom, path="drive", status=inserted
-#ata0-slave: type=cdrom, path=/dev/rcd0d, status=inserted 
+#ata0-slave: type=cdrom, path=/dev/rcd0d, status=inserted
 
 #=======================================================================
 # BOOT:
@@ -817,7 +817,7 @@ log: bochsout.txt
 #   %i : 8 hexadecimal digits of cpu current eip (ignored in SMP configuration)
 #   %e : 1 character event type ('i'nfo, 'd'ebug, 'p'anic, 'e'rror)
 #   %d : 5 characters string of the device, between brackets
-# 
+#
 # Default : %t%e%d
 # Examples:
 #   logprefix: %t-%e-@%i-%d
@@ -829,7 +829,7 @@ log: bochsout.txt
 # LOG CONTROLS
 #
 # Bochs has four severity levels for event logging.
-#   panic: cannot proceed.  If you choose to continue after a panic, 
+#   panic: cannot proceed.  If you choose to continue after a panic,
 #          don't be surprised if you get strange behavior or crashes.
 #   error: something went wrong, but it is probably safe to continue the
 #          simulation.
@@ -1054,7 +1054,7 @@ speaker: enabled=1, mode=sound, volume=15
 # ETHDEV: The ethdev value is the name of the network interface on your host
 # platform.  On UNIX machines, you can get the name by running ifconfig.  On
 # Windows machines, you must run niclist to get the name of the ethdev.
-# Niclist source code is in misc/niclist.c and it is included in Windows 
+# Niclist source code is in misc/niclist.c and it is included in Windows
 # binary releases.
 # The 'socket' module uses this parameter to specify the UDP port for
 # receiving packets and (optional) the host to connect.
@@ -1300,7 +1300,7 @@ speaker: enabled=1, mode=sound, volume=15
 
 #=======================================================================
 # MEGS
-# Set the number of Megabytes of physical memory you want to emulate. 
+# Set the number of Megabytes of physical memory you want to emulate.
 # The default is 32MB, most OS's won't need more than that.
 # The maximum amount of memory supported is 2048Mb.
 # The 'MEGS' option is deprecated. Use 'MEMORY' option instead.

--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -5927,6 +5927,26 @@ features enabled at compile time (3rd column).
     <entry>Intel(R) Processor 5Y70 CPU (Broadwell)</entry>
     <entry>cpu level 6, x86-64, avx</entry>
   </row>
+  <row>
+    <entry>corei7_skylake_x</entry>
+    <entry>Intel(R) Core(TM) i7-7800X CPU (Skylake)</entry>
+    <entry>cpu level 6, x86-64, avx</entry>
+  </row>
+  <row>
+    <entry>corei3_cnl</entry>
+    <entry>Intel(R) Core(TM) i3-8121U CPU (Cannonlake)</entry>
+    <entry>cpu level 6, x86-64, avx</entry>
+  </row>
+  <row>
+    <entry>corei7_icelake_u</entry>
+    <entry>QuadCore Intel Core i7-1065G7 (IceLake)</entry>
+    <entry>cpu level 6, x86-64, avx</entry>
+  </row>
+  <row>
+    <entry>tigerlake</entry>
+    <entry>11th Gen Intel(R) Core(TM) i5-1135G7 (TigerLake)</entry>
+    <entry>cpu level 6, x86-64, avx</entry>
+  </row>
 </tbody>
 </tgroup>
 </table>

--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -33,7 +33,7 @@ This is the top level file for the Bochs Users Manual.
 <chapter id="introduction"><title>Introduction to Bochs</title>
 <section id="whatisbochs"><title>What is Bochs?</title>
 <para>
-Bochs is a program that simulates a complete Intel x86 computer.  
+Bochs is a program that simulates a complete Intel x86 computer.
 It includes emulation of the Intel x86 CPU, common I/O devices,
 and a custom BIOS. Bochs can be compiled to emulate many different
 x86 CPUs, from early 386 to the most recent x86-64 Intel and AMD
@@ -2653,10 +2653,10 @@ This example shows the output of a compilation and installation on Linux.
   g++ -o bochs -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -DBX_SHARE_PATH=\"/usr/local/share/bochs\" logio.o main.o config.o load32bitOShack.o pc_system.o osdep.o plugin.o crc.o -Wl,--export-dynamic  iodev/libiodev.a cpu/libcpu.a cpu/cpudb/libcpudb.a memory/libmemory.a gui/libgui.a disasm/libdisasm.a fpu/libfpu.a -lSM -lICE -lX11 -lXpm -lXrandr -lm
   gcc -c -I. -I./. -Iinstrument/stubs -I./instrument/stubs -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES   ./misc/bximage.c -o misc/bximage.o
   /bin/sh ./libtool --mode=link g++ -o bximage -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES     misc/bximage.o
-  g++ -o bximage -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES misc/bximage.o 
+  g++ -o bximage -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES misc/bximage.o
   gcc -c -I. -I./. -Iinstrument/stubs -I./instrument/stubs -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES   ./misc/bxcommit.c -o misc/bxcommit.o
   /bin/sh ./libtool --mode=link g++ -o bxcommit -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES    misc/bxcommit.o
-  g++ -o bxcommit -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES misc/bxcommit.o 
+  g++ -o bxcommit -g -O2 -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES misc/bxcommit.o
   user$ <command>su</command>
   root# <command>make install</command>
   cd iodev && \
@@ -3525,7 +3525,7 @@ See example in msrs.def.
 <para><command>ignore_bad_msrs</command></para>
 <para>
 Ignore MSR references that Bochs does not understand; print a warning message
-instead of generating #GP exception. This option is enabled by default but 
+instead of generating #GP exception. This option is enabled by default but
 will not be available if configurable MSRs are enabled.
 </para>
 <para><anchor id="bochsopt-cpu-ips"><command>ips</command></para>
@@ -3936,7 +3936,7 @@ Approximate time in microseconds between attempts to paste
 characters to the keyboard controller. This leaves time for the
 guest os to deal with the flow of characters.  The ideal setting
 depends on how your operating system processes characters.  The
-default of 100000 usec (.1 seconds) was chosen because it works 
+default of 100000 usec (.1 seconds) was chosen because it works
 consistently in Windows.
 </para>
 <para>
@@ -4046,7 +4046,7 @@ to AGP.
 </para>
 <para><command>advopts</command></para>
 <para>
-With the advanced PCI options it is possible to control the behaviour of the 
+With the advanced PCI options it is possible to control the behaviour of the
 PCI chipset. These options can be specified as comma-separated values.
 By default the "Bochs i440FX" chipset enables the ACPI and HPET devices, but
 original i440FX doesn't support them. The options 'noacpi' and 'nohpet' make
@@ -5131,7 +5131,7 @@ define a convention here, to display on the console of the system running
 Bochs anything that is written to it. The idea is to provide debug output
 very early when writing BIOS or OS code for example, without having to
 bother with setting up a serial port or etc. Reading from port 0xE9 will
-will return 0xe9 to let you know if the feature is available. Leave  
+will return 0xe9 to let you know if the feature is available. Leave
 this 0 unless you have a reason to use it.
 </para>
 </section>
@@ -5676,7 +5676,7 @@ Some of these features may not be implemented or work different on your host pla
 
 <section id="command-mode"><title>Command mode</title>
 <para>
-When using 'sdl', 'sdl2', 'win32' or 'x' as the <command>display_library</command>, the 
+When using 'sdl', 'sdl2', 'win32' or 'x' as the <command>display_library</command>, the
 option 'cmdmode' enables the "command mode" support. If enabled, pressing the F7
 key will enter 'command mode' (shown in the info item of the statusbar);
 the next key that is pressed will exit command-mode. When in command-mode,
@@ -6704,10 +6704,10 @@ From here, you may use the following commands:
 
   calc|? expr       Evaluate an expression and display the result.
                     'expr' can reference any general-purpose, opmask and segment
-                    registers, use any arithmetic and logic operations, and also 
-                    special ':' operator which computes the linear address of a 
-                    segment:offset (in real and v86 mode) or of a selector:offset 
-                    (in protected mode) pair. Use $ operator for dereference, 
+                    registers, use any arithmetic and logic operations, and also
+                    special ':' operator which computes the linear address of a
+                    segment:offset (in real and v86 mode) or of a selector:offset
+                    (in protected mode) pair. Use $ operator for dereference,
                     for example get value of [[[rax]]] or ***rax: rax$3.
 
 </screen>


### PR DESCRIPTION
This change adds 4 missing pre-defined CPU model names. This is document-only change. 

Review commit by commit. The first commit is trailing space removal only. 2nd commit is the actual change. Model descriptions are as appear in the `brand_string`, followed by generation names.