### PR TITLE
add layout commands for dbg

### DIFF
--- a/bochs/bx_debug/dbg_main.cc
+++ b/bochs/bx_debug/dbg_main.cc
@@ -62,6 +62,8 @@ static char tmp_buf_prev[512];
 static char *tmp_buf_ptr;
 static char *argv0 = NULL;
 
+static char layoutpath[BX_MAX_PATH];
+
 static FILE *debugger_log = NULL;
 
 static struct bx_debugger_state {
@@ -2258,6 +2260,29 @@ void bx_dbg_disassemble_current(int which_cpu, int print_time)
   }
 }
 
+void bx_dbg_addlyt(const char* new_layoutpath)
+{
+  if (strlen(new_layoutpath) > sizeof(layoutpath) - 1) {
+    dbg_printf("Error: %s path too long!\n", new_layoutpath);
+    return;
+  }
+  strcpy(layoutpath, new_layoutpath);
+}
+
+void bx_dbg_remlyt(void)
+{
+  layoutpath[0] = '\0';
+}
+
+void bx_dbg_lyt(void)
+{
+  if ('\0' == layoutpath[0]) {
+    return;
+  }
+
+  bx_nest_infile(layoutpath);
+}
+
 void bx_dbg_print_guard_results(void)
 {
   unsigned cpu, i;
@@ -2321,6 +2346,10 @@ void bx_dbg_print_guard_results(void)
     default:
         dbg_printf("Error: (%u) print_guard_results: guard_found ? (stop reason %u)\n",
           cpu, BX_CPU(cpu)->stop_reason);
+    }
+	
+    if (cpu == 0) {
+      bx_dbg_lyt();
     }
 
     if (bx_debugger.auto_disassemble) {
@@ -3757,7 +3786,7 @@ void bx_dbg_print_help(void)
   dbg_printf("h|help command - show short command description\n");
   dbg_printf("-*- Debugger control -*-\n");
   dbg_printf("    help, q|quit|exit, set, instrument, show, trace, trace-reg,\n");
-  dbg_printf("    trace-mem, u|disasm, ldsym, slist\n");
+  dbg_printf("    trace-mem, u|disasm, ldsym, slist, addlyt, remlyt, lyt\n");
   dbg_printf("-*- Execution control -*-\n");
   dbg_printf("    c|cont|continue, s|step, p|n|next, modebp, vmexitbp\n");
   dbg_printf("-*- Breakpoint management -*-\n");

--- a/bochs/bx_debug/debug.h
+++ b/bochs/bx_debug/debug.h
@@ -73,6 +73,9 @@ bool bx_dbg_register_debug_info(const char *devname, void *dev);
 
 #define EMPTY_ARG (-1)
 
+void bx_dbg_addlyt(const char* new_layoutpath);
+void bx_dbg_remlyt(void);
+void bx_dbg_lyt(void);
 bool bx_dbg_read_linear(unsigned which_cpu, bx_address laddr, unsigned len, Bit8u *buf);
 bool bx_dbg_write_linear(unsigned which_cpu, bx_address laddr, unsigned len, Bit8u *buf);
 Bit16u bx_dbg_get_selector_value(unsigned int seg_no);

--- a/bochs/bx_debug/lexer.l
+++ b/bochs/bx_debug/lexer.l
@@ -238,6 +238,9 @@ xml             { bxlval.sval = strdup(bxtext); return(BX_TOKEN_XML); }
 h|help          { bxlval.sval = strdup(bxtext); return(BX_TOKEN_HELP); }
 \?              |
 calc            { bxlval.sval = strdup(bxtext); return(BX_TOKEN_CALC); }
+addlyt          { bxlval.sval = strdup(bxtext); return(BX_TOKEN_ADDLYT); }
+remlyt          { bxlval.sval = strdup(bxtext); return(BX_TOKEN_REMLYT); }
+lyt             { bxlval.sval = strdup(bxtext); return(BX_TOKEN_LYT); }
 <EXAMINE>\/[0-9]+                 { BEGIN(INITIAL); bxlval.sval = strdup(bxtext); return(BX_TOKEN_XFORMAT); }
 <EXAMINE>\/[0-9]*[mxduotcsibhwg]+ { BEGIN(INITIAL); bxlval.sval = strdup(bxtext); return(BX_TOKEN_XFORMAT); }
 <DISASM>\/[0-9]+        { BEGIN(INITIAL); bxlval.sval = strdup(bxtext); return(BX_TOKEN_DISFORMAT); }

--- a/bochs/bx_debug/parser.y
+++ b/bochs/bx_debug/parser.y
@@ -123,6 +123,9 @@ Bit64u eval_value;
 %token <sval> BX_TOKEN_HELP
 %token <sval> BX_TOKEN_XML
 %token <sval> BX_TOKEN_CALC
+%token <sval> BX_TOKEN_ADDLYT
+%token <sval> BX_TOKEN_REMLYT
+%token <sval> BX_TOKEN_LYT
 %token <sval> BX_TOKEN_DEVICE
 %token <sval> BX_TOKEN_GENERIC
 %token BX_TOKEN_DEREF_CHR
@@ -205,6 +208,9 @@ command:
     | print_string_command
     | help_command
     | calc_command
+    | addlyt_command
+    | remlyt_command
+    | lyt_command
     | if_command
     | expression { eval_value = $1; }
     |
@@ -1321,6 +1327,29 @@ help_command:
          dbg_printf("    ***rax: rax$3\n");
          free($1);free($2);
        }
+     | BX_TOKEN_HELP BX_TOKEN_ADDLYT '\n'
+       {
+         dbg_printf("addlyt file - cause debugger to execute a script file every time execution stops.\n");
+         dbg_printf("    Example of use: 1. Create a script file (script.txt) with the following content:\n");
+         dbg_printf("             regs\n");
+         dbg_printf("             print-stack 7\n");
+         dbg_printf("             u /10\n");
+         dbg_printf("             <EMPTY NEW LINE>\n");
+         dbg_printf("    2. Execute: addlyt \"script.txt\"\n");
+         dbg_printf("    Then, when you execute a step/DebugBreak... you will see: registers, stack and disasm.\n");
+         free($1);free($2);
+       }
+     | BX_TOKEN_HELP BX_TOKEN_REMLYT '\n'
+       {
+         dbg_printf("remlyt - stops debugger to execute the script file added previously with addlyt command.\n");
+         free($1);free($2);
+       }
+     | BX_TOKEN_HELP BX_TOKEN_LYT '\n'
+       {
+         dbg_printf("lyt - cause debugger to execute script file added previously with addlyt command.\n");
+         dbg_printf("    Use it as a refresh/context.\n");
+         free($1);free($2);
+       }
      | BX_TOKEN_HELP BX_TOKEN_HELP '\n'
        {
          bx_dbg_print_help();
@@ -1338,6 +1367,31 @@ calc_command:
    {
      eval_value = $2;
      bx_dbg_calc_command($2);
+     free($1);
+   }
+;
+
+addlyt_command:
+   BX_TOKEN_ADDLYT BX_TOKEN_STRING '\n'
+   {
+     bx_dbg_addlyt($2);
+     free($1);
+     free($2);
+   }
+;
+
+remlyt_command:
+   BX_TOKEN_REMLYT '\n'
+   {
+     bx_dbg_remlyt();
+     free($1);
+   }
+;
+
+lyt_command:
+   BX_TOKEN_LYT '\n'
+   {
+     bx_dbg_lyt();
      free($1);
    }
 ;


### PR DESCRIPTION
Layout support (our GDB-TUI for poors :D):

```
addlyt file - cause debugger to execute a script file every time execution stops.
    Example of use: 1. Create a script file (script.txt) with the following content:
             regs            
             print-stack 7
             u /10
             <EMPTY NEW LINE>
    2. Execute: addlyt "script.txt"
    Then, when you execute a step/DebugBreak... you will see: registers, stack and disasm.
```
```
remlyt - stops debugger to execute the script file added previously with addlyt command.
```
```
lyt - cause debugger to execute script file added previously with addlyt command.
    Use it as a refresh/context.
```

Example of use:

![layout](https://user-images.githubusercontent.com/9882181/187239549-eeef400c-ecee-494b-a2ba-bcfe5d089ab3.PNG)

![example_of_use_layout](https://user-images.githubusercontent.com/9882181/187236319-aead7863-082e-48f5-9243-c3e93f519e64.PNG)

Re-execute layout:

![reload_layout](https://user-images.githubusercontent.com/9882181/187236728-9950a87b-24f4-4e7d-987e-2668c1583522.PNG)

IMO, this will be **one of the most used features**.  (search_in_history or write same commands each time its a pain in the ass)

One idea: the user can have some script files with different layouts/things and change between them using **addlyt** command

To keep this feature short and simple I am using **bx_nest_infile()** (used by **source** command).

Only 1 layout/file is supported at time. 
