### PR TITLE
add dbghelp for source, bt and print-string commands

### DIFF
--- a/bochs/bx_debug/dbg_main.cc
+++ b/bochs/bx_debug/dbg_main.cc
@@ -3786,7 +3786,7 @@ void bx_dbg_print_help(void)
   dbg_printf("h|help command - show short command description\n");
   dbg_printf("-*- Debugger control -*-\n");
   dbg_printf("    help, q|quit|exit, set, instrument, show, trace, trace-reg,\n");
-  dbg_printf("    trace-mem, u|disasm, ldsym, slist, addlyt, remlyt, lyt\n");
+  dbg_printf("    trace-mem, u|disasm, ldsym, slist, addlyt, remlyt, lyt, source\n");
   dbg_printf("-*- Execution control -*-\n");
   dbg_printf("    c|cont|continue, s|step, p|n|next, modebp, vmexitbp\n");
   dbg_printf("-*- Breakpoint management -*-\n");
@@ -3795,7 +3795,7 @@ void bx_dbg_print_help(void)
   dbg_printf("-*- CPU and memory contents -*-\n");
   dbg_printf("    x, xp, setpmem, writemem, loadmem, crc, info, deref,\n");
   dbg_printf("    r|reg|regs|registers, fp|fpu, mmx, sse, sreg, dreg, creg,\n");
-  dbg_printf("    page, set, ptime, print-stack, bt, ?|calc\n");
+  dbg_printf("    page, set, ptime, print-stack, bt, print-string, ?|calc\n");
   dbg_printf("-*- Working with bochs param tree -*-\n");
   dbg_printf("    show \"param\", restore\n");
 }

--- a/bochs/bx_debug/lexer.l
+++ b/bochs/bx_debug/lexer.l
@@ -241,6 +241,7 @@ calc            { bxlval.sval = strdup(bxtext); return(BX_TOKEN_CALC); }
 addlyt          { bxlval.sval = strdup(bxtext); return(BX_TOKEN_ADDLYT); }
 remlyt          { bxlval.sval = strdup(bxtext); return(BX_TOKEN_REMLYT); }
 lyt             { bxlval.sval = strdup(bxtext); return(BX_TOKEN_LYT); }
+source          { bxlval.sval = strdup(bxtext); return(BX_TOKEN_SOURCE); }
 <EXAMINE>\/[0-9]+                 { BEGIN(INITIAL); bxlval.sval = strdup(bxtext); return(BX_TOKEN_XFORMAT); }
 <EXAMINE>\/[0-9]*[mxduotcsibhwg]+ { BEGIN(INITIAL); bxlval.sval = strdup(bxtext); return(BX_TOKEN_XFORMAT); }
 <DISASM>\/[0-9]+        { BEGIN(INITIAL); bxlval.sval = strdup(bxtext); return(BX_TOKEN_DISFORMAT); }

--- a/bochs/bx_debug/parser.y
+++ b/bochs/bx_debug/parser.y
@@ -126,6 +126,7 @@ Bit64u eval_value;
 %token <sval> BX_TOKEN_ADDLYT
 %token <sval> BX_TOKEN_REMLYT
 %token <sval> BX_TOKEN_LYT
+%token <sval> BX_TOKEN_SOURCE
 %token <sval> BX_TOKEN_DEVICE
 %token <sval> BX_TOKEN_GENERIC
 %token BX_TOKEN_DEREF_CHR
@@ -1147,6 +1148,11 @@ help_command:
          dbg_printf("print-stack [num_words] - print the num_words top 16 bit words on the stack\n");
          free($1);free($2);
        }
+     | BX_TOKEN_HELP BX_TOKEN_BT '\n'
+       {
+         dbg_printf("bt [num_entries] - prints backtrace\n");
+         free($1);free($2);
+       }
      | BX_TOKEN_HELP BX_TOKEN_LOAD_SYMBOLS '\n'
        {
          dbg_printf("ldsym [global] <filename> [offset] - load symbols from file\n");
@@ -1329,7 +1335,7 @@ help_command:
        }
      | BX_TOKEN_HELP BX_TOKEN_ADDLYT '\n'
        {
-         dbg_printf("addlyt file - cause debugger to execute a script file every time execution stops.\n");
+         dbg_printf("addlyt <file> - cause debugger to execute a script file every time execution stops.\n");
          dbg_printf("    Example of use: 1. Create a script file (script.txt) with the following content:\n");
          dbg_printf("             regs\n");
          dbg_printf("             print-stack 7\n");
@@ -1348,6 +1354,16 @@ help_command:
        {
          dbg_printf("lyt - cause debugger to execute script file added previously with addlyt command.\n");
          dbg_printf("    Use it as a refresh/context.\n");
+         free($1);free($2);
+       }
+     | BX_TOKEN_HELP BX_TOKEN_PRINT_STRING '\n'
+       {
+         dbg_printf("print-string <addr> - prints a null-ended string from a linear address.\n");
+         free($1);free($2);
+       }
+     | BX_TOKEN_HELP BX_TOKEN_SOURCE '\n'
+       {
+         dbg_printf("source <file> - cause debugger to execute a script file.\n");
          free($1);free($2);
        }
      | BX_TOKEN_HELP BX_TOKEN_HELP '\n'

--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -6812,7 +6812,8 @@ the "instrument/stubs" directory to it, then customize it.  Use:
 <title>Instrumentation commands</title>
 <para>
 <screen>
-  instrument [command]        calls BX_INSTR_DEBUG_CMD instrumentation callback with [command]
+  instrument [command]          calls BX_INSTR_DEBUG_CMD instrumentation callback with [command]
+  instrument "[command string]" calls BX_INSTR_DEBUG_CMD instrumentation callback with [command string]
 </screen>
 </para>
 </section>
@@ -6838,6 +6839,40 @@ Insert a time break point at "time" ("time" is a 64-bit integer followed by "L",
 Print the <varname>num words</varname> top 16-bit words on the stack. <varname>Num
 words</varname> defaults to 16. Only works reliably in protected mode when
 the base address of the stack segment is zero.
+
+<screen>print-string addr</screen>
+
+prints a null-ended string from a linear address.
+
+<screen>bt [num_entries]</screen>
+
+prints backtrace.
+
+<screen>source file</screen>
+
+cause debugger to execute a script file
+
+<screen>addlyt file</screen>
+
+cause debugger to execute a script file every time execution stops. Example of use: 
+
+1. Create a script file (script.txt) with the following content:
+    regs
+    print-stack 7
+    u /10
+    <EMPTY NEW LINE>
+2. Execute: addlyt "script.txt"
+
+Then, when you execute a step/DebugBreak... you will see: registers, stack and disasm.
+
+<screen>remlyt</screen>
+
+stops debugger to execute the script file added previously with addlyt command.
+
+<screen>lyt</screen>
+
+cause debugger to execute script file added previously with addlyt command. 
+Use it as a refresh/context.
 
 <screen>modebp</screen>
 


### PR DESCRIPTION
Add help for **three** existing commands: **bt**, **source** & **print-string**

![helpadded](https://user-images.githubusercontent.com/9882181/189526968-4a733a02-516e-46ba-8203-0af7e20ebaee.png)

NOTE: **source** command is implemented in **dbg_main.cc** (for this reason I only add **BX_TOKEN_SOURCE** for **help source** command)

![helpbt](https://user-images.githubusercontent.com/9882181/189613955-5f9b3b25-abba-42e2-8761-5afbaf573651.png)

