### PR TITLE
Fix dbgdoc user.dbk broken with PR #12

### DIFF
--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -6854,17 +6854,34 @@ cause debugger to execute a script file
 
 <screen>addlyt file</screen>
 
-cause debugger to execute a script file every time execution stops. Example of use: 
+cause debugger to execute a script file every time execution stops. 
+</para>
 
-1. Create a script file (script.txt) with the following content:
+<para>
+Example of use: 
+</para>
+
+<para>
+Create a script file (script.txt) with the following content
+</para>
+<screen>
     regs
     print-stack 7
     u /10
-    <EMPTY NEW LINE>
-2. Execute: addlyt "script.txt"
+    (*EMPTY NEW LINE)
+</screen>
 
+<para>
+Execute addlyt
+</para>
+<screen>
+addlyt "script.txt"
+</screen>
+
+<para>
 Then, when you execute a step/DebugBreak... you will see: registers, stack and disasm.
-
+</para>
+<para>
 <screen>remlyt</screen>
 
 stops debugger to execute the script file added previously with addlyt command.


### PR DESCRIPTION
Fix dbgdoc user.dbk broken with PR #12 

Reported by @vruppert: 

https://github.com/bochs-emu/Bochs/commit/d514779177e88235ed00c11546ee732ad86e233e#commitcomment-84314677

Sorry for my fault, it was my first time with this kind of doc :\

Web output with this PR:

![newdoc](https://user-images.githubusercontent.com/9882181/190941778-fc767630-ae43-4c94-96e2-e7f094e50e65.png)
