### PR TITLE
Fix windows build

### DIFF
--- a/bochs/build/win32/vs2019-workspace/vs2019/avx.vcxproj
+++ b/bochs/build/win32/vs2019-workspace/vs2019/avx.vcxproj
@@ -129,6 +129,7 @@
     <ClCompile Include="..\cpu\avx\avx512_pfp.cc" />
     <ClCompile Include="..\cpu\avx\avx512_rcp14.cc" />
     <ClCompile Include="..\cpu\avx\avx512_rsqrt14.cc" />
+    <ClCompile Include="..\cpu\avx\avx_ifma52.cc" />
     <ClCompile Include="..\cpu\avx\vnni.cc" />
     <ClCompile Include="..\cpu\avx\avx_cvt.cc" />
     <ClCompile Include="..\cpu\avx\avx_fma.cc" />

--- a/bochs/build/win32/vs2019-workspace/vs2019/cpu.vcxproj
+++ b/bochs/build/win32/vs2019-workspace/vs2019/cpu.vcxproj
@@ -132,6 +132,8 @@
     <ClCompile Include="..\cpu\bmi64.cc" />
     <ClCompile Include="..\cpu\call_far.cc" />
     <ClCompile Include="..\cpu\cet.cc" />
+    <ClCompile Include="..\cpu\cmpccxadd32.cc" />
+    <ClCompile Include="..\cpu\cmpccxadd64.cc" />
     <ClCompile Include="..\cpu\cpu.cc" />
     <ClCompile Include="..\cpu\cpuid.cc" />
     <ClCompile Include="..\cpu\crc32.cc" />


### PR DESCRIPTION
Few new files are required to build Bochs on Windows but not included in the Visual Studio solution. Add them and fixes link errors.