### PR TITLE
Check breakpoints before icount guard

### DIFF
--- a/bochs/cpu/cpu.cc
+++ b/bochs/cpu/cpu.cc
@@ -699,13 +699,6 @@ bool BX_CPU_C::dbg_instruction_epilog(void)
     return(1); // on a breakpoint
   }
 
-  // see if debugger requesting icount guard
-  if (bx_guard.guard_for & BX_DBG_GUARD_ICOUNT) {
-    if (get_icount() >= BX_CPU_THIS_PTR guard_found.icount_max) {
-      return(1);
-    }
-  }
-
   // convenient point to see if user requested debug break or typed Ctrl-C
   if (bx_guard.interrupt_requested) {
     return(1);
@@ -770,6 +763,13 @@ bool BX_CPU_C::dbg_instruction_epilog(void)
       }
     }
 #endif
+  }
+
+  // see if debugger requesting icount guard
+  if (bx_guard.guard_for & BX_DBG_GUARD_ICOUNT) {
+    if (get_icount() >= BX_CPU_THIS_PTR guard_found.icount_max) {
+      return(1);
+    }
   }
 #endif
 


### PR DESCRIPTION
It seems that sometimes breakpoints do not fire if there are several cpu.
To reproduce this issue, try to launch Bochs with the following configuration file:
```
memory: guest=64, host=64
romimage: file=$BXSHARE/BIOS-bochs-latest
vgaromimage: file=$BXSHARE/VGABIOS-lgpl-latest
cpu: model=core2_penryn_t9600, count=2
```
Then run bochs, enter the following commands:
```
bp 0xfe063
c
```
Observe that the breakpoint does not work, the execution continues until simulation is killed due to absence of bootable device.
If the breakpoint does work, try to break on nearby instructions instead, it is not easy to reproduce the issue 100% accurately.

It seems that when there are several reasons to stop cpu_loop, as soon as the first reason is found, checks for other reasons are skipped. So, when cpu_loop is to exit due to quantum exhaustion, the code testing for breakpoints is not reached, so the "c" command continues execution. I suggest to move the check for icount guard to be the last check.