### PR TITLE
patched an issue with the HPET

### DIFF
--- a/bochs/iodev/hpet.h
+++ b/bochs/iodev/hpet.h
@@ -97,7 +97,7 @@ public:
 #endif
 
   Bit32u read_aligned(bx_phy_address address);
-  void write_aligned(bx_phy_address address, Bit32u data);
+  void write_aligned(bx_phy_address address, Bit32u data, bool trailing_write);
 
 private:
   Bit32u hpet_in_legacy_mode(void) {return s.config & HPET_CFG_LEGACY;}


### PR DESCRIPTION
Patched an issue with the HPET where writing an u64 with HPET_TN_SETVAL set, would only write the lower 32bits into the comparator. This is because the write is getting split into two 32bit writes and the first 32bit write will disable HPET_TN_SETVAL.