### PR TITLE
cpudb: extend strings that are too small

### DIFF
--- a/bochs/cpu/cpudb/amd/turion64_tyler.cc
+++ b/bochs/cpu/cpudb/amd/turion64_tyler.cc
@@ -72,7 +72,7 @@ turion64_tyler_t::turion64_tyler_t(BX_CPU_C *cpu): bx_cpuid_t(cpu)
 
 void turion64_tyler_t::get_cpuid_leaf(Bit32u function, Bit32u subfunction, cpuid_function_t *leaf) const
 {
-  static const char* brand_string = "AMD Turion(tm) 64 X2 Mobile Technology TL-60";
+  static const char* brand_string = "AMD Turion(tm) 64 X2 Mobile Technology TL-60\0\0\0";
 
   switch(function) {
   case 0x80000000:

--- a/bochs/cpu/cpudb/intel/corei7_icelake-u.cc
+++ b/bochs/cpu/cpudb/intel/corei7_icelake-u.cc
@@ -134,7 +134,7 @@ corei7_icelake_t::corei7_icelake_t(BX_CPU_C *cpu):
 
 void corei7_icelake_t::get_cpuid_leaf(Bit32u function, Bit32u subfunction, cpuid_function_t *leaf) const
 {
-  static const char* brand_string = "QuadCore Intel Core i7-1065G7, 1300 MHz\0\0\0\0\0\0\0";
+  static const char* brand_string = "QuadCore Intel Core i7-1065G7, 1300 MHz\0\0\0\0\0\0\0\0";
 
   static bool cpuid_limit_winnt = SIM->get_param_bool(BXPN_CPUID_LIMIT_WINNT)->get();
   if (cpuid_limit_winnt)

--- a/bochs/cpu/cpudb/intel/tigerlake.cc
+++ b/bochs/cpu/cpudb/intel/tigerlake.cc
@@ -138,7 +138,7 @@ tigerlake_t::tigerlake_t(BX_CPU_C *cpu):
 
 void tigerlake_t::get_cpuid_leaf(Bit32u function, Bit32u subfunction, cpuid_function_t *leaf) const
 {
-  static const char* brand_string = "11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz";
+  static const char* brand_string = "11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz\0";
 
   static bool cpuid_limit_winnt = SIM->get_param_bool(BXPN_CPUID_LIMIT_WINNT)->get();
   if (cpuid_limit_winnt)


### PR DESCRIPTION
This was caught by ASAN. The brand_string is copied as:

```
void bx_cpuid_t::get_ext_cpuid_brand_string_leaf(const char *brand_string, Bit32u function, cpuid_function_t *leaf) const
{
  switch(function) {
  case 0x80000002:
    memcpy(&(leaf->eax), brand_string     , 4);
    memcpy(&(leaf->ebx), brand_string +  4, 4);
    memcpy(&(leaf->ecx), brand_string +  8, 4);
    memcpy(&(leaf->edx), brand_string + 12, 4);
    break;
  case 0x80000003:
    memcpy(&(leaf->eax), brand_string + 16, 4);
    memcpy(&(leaf->ebx), brand_string + 20, 4);
    memcpy(&(leaf->ecx), brand_string + 24, 4);
    memcpy(&(leaf->edx), brand_string + 28, 4);
    break;
  case 0x80000004:
    memcpy(&(leaf->eax), brand_string + 32, 4);
    memcpy(&(leaf->ebx), brand_string + 36, 4);
    memcpy(&(leaf->ecx), brand_string + 40, 4);
    memcpy(&(leaf->edx), brand_string + 44, 4);
    break;
  default:
    break;
  }
```

But, this assumes the string is long enough (48 including the terminating nul char). Some of those strings were shorter. I believe the right behavior is to manually add padding (like it's done in other files).