### PR TITLE
Fix issue #25

### DIFF
--- a/bochs/iodev/usb/usb_common.cc
+++ b/bochs/iodev/usb/usb_common.cc
@@ -274,6 +274,7 @@ usb_device_c *usbdev_locator_c::create(const char *type, const char *devname)
 usb_device_c::usb_device_c(void)
 {
   memset((void *) &d, 0, sizeof(d));
+  d.pcapture.pcap_image_init();
   d.async_mode = 1;
   d.speed = USB_SPEED_LOW;
   d.first8 = 0;
@@ -687,7 +688,7 @@ int usb_device_c::handle_control_common(int request, int value, int index, int l
       }
       break;
     case InterfaceRequest | USB_REQ_GET_INTERFACE:
-      // Ben TODO: If the device is not in the configured state, this request should stall
+      // Ben: TODO: If the device is not in the configured state, this request should stall
       BX_DEBUG(("USB_REQ_GET_INTERFACE:"));
       // with InterfaceRequest, the wValue field must be zero and wLength field must be 1
       if ((value != 0) || (length != 1)) {
@@ -701,7 +702,7 @@ int usb_device_c::handle_control_common(int request, int value, int index, int l
       }
       break;
     case InterfaceOutRequest | USB_REQ_SET_INTERFACE:
-      // Ben TODO: If the device is not in the configured state, this request should stall
+      // Ben: TODO: If the device is not in the configured state, this request should stall
       BX_DEBUG(("USB_REQ_SET_INTERFACE: value=%d", value));
       // with InterfaceRequest, the wIndex and wLength fields must be zero
       if ((index != 0) || (length != 0)) {

--- a/bochs/iodev/usb/usb_pcap.cc
+++ b/bochs/iodev/usb/usb_pcap.cc
@@ -54,18 +54,18 @@
 
 /*** base class pcap_image_t ***/
 
-pcap_image_t::pcap_image_t()
-{
-  fd = -1;
-  last_pos = 0;
-  time_usecs = 0;
-}
-
 pcap_image_t::~pcap_image_t()
 {
   if (fd > -1)
     close(fd);
   fd = -1;
+}
+
+void pcap_image_t::pcap_image_init()
+{
+  fd = -1;
+  last_pos = 0;
+  time_usecs = 0;
 }
 
 int pcap_image_t::create_pcap(const char *pathname)

--- a/bochs/iodev/usb/usb_pcap.h
+++ b/bochs/iodev/usb/usb_pcap.h
@@ -92,9 +92,9 @@ struct usbmon_packet {
 class BOCHSAPI_MSVCONLY pcap_image_t
 {
   public:
-    // Default constructor
-    pcap_image_t();
+    // Uses a default constructor
     ~pcap_image_t();
+    void pcap_image_init();
 
     // append a packet to the pcap file
     int create_pcap(const char *filename);


### PR DESCRIPTION
The 'd.pcap_image_t pcapture' in usb_common.h called its constructor and set 'fd' to -1. However, in the usb_device_c() constructor, we then cleared all of 'd', resetting pcapture.fd back to zero. Then on Bochs exit, the pcap_image_t destructor tried to close the file since 'fd' was zero instead of -1. To fix this, I removed the pcap_image_t constructor and now call pcap_image_init() within the usb_device_c constructor.