### PR TITLE
Updates to USBMSD/SCSI emulation

### DIFF
--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -6294,6 +6294,9 @@ usb_ohci: enabled=1, port1=mouse, options1="speed:full"
 usb_ehci: enabled=1, port1=mouse, options1="speed:high"
 usb_xhci: enabled=3, port3=mouse, options1="speed:full"
 </screen>
+<note><para>
+Please note that most physical USB mice will be 'low-speed' only.
+</para></note>
 </para>
 </section>
 
@@ -6311,6 +6314,9 @@ usb_ohci: enabled=1, port1=keyboard, options1="speed:full"
 usb_ehci: enabled=1, port1=keyboard, options1="speed:high"
 usb_xhci: enabled=3, port3=keyboard, options1="speed:full"
 </screen>
+<note><para>
+Please note that most physical USB keyboards will be 'low-speed' only.
+</para></note>
 </para>
 </section>
 
@@ -6328,6 +6334,9 @@ usb_ohci: enabled=1, port1=keypad, options1="speed:full"
 usb_ehci: enabled=1, port1=keypad, options1="speed:high"
 usb_xhci: enabled=3, port3=keypad, options1="speed:full"
 </screen>
+<note><para>
+Please note that most physical USB keypads will be 'low-speed' only.
+</para></note>
 </para>
 </section>
 
@@ -6354,6 +6363,9 @@ usb_ohci: enabled=1, port1=tablet, options1="speed:full"
 usb_ehci: enabled=1, port1=tablet, options1="speed:high"
 usb_xhci: enabled=3, port3=tablet, options1="speed:full"
 </screen>
+<note><para>
+Please note that most physical USB tablets will be 'low-speed' only.
+</para></note>
 </para>
 </section>
 
@@ -6391,6 +6403,9 @@ the 'path' accordingly.
 Specifying 'proto:uasp' does not guarantee that the Guest will use that protocol.
 See a <link linkend="bochsopt-usb-uhci">previous section</link> for more information.
 </para></note>
+<note><para>
+Please note that this device is not allowed as a low-speed only device. Low-speed should be specified.
+</para></note>
 </para>
 </section>
 
@@ -6416,6 +6431,9 @@ usb_uhci: enabled=1, port1=floppy, options1="speed:full, path:<emphasis>mode</em
 The 'model:teac' option can be used to emulate that specific model, else a default
 model will be used. If a guest does not see the attached floppy, try specifying the 'teac'
 model.
+<note><para>
+Please note that this device is a full-speed only device. No other speed should be specified.
+</para></note>
 </para>
 </section>
 
@@ -6432,6 +6450,9 @@ usb_ohci: enabled=1, port1=printer, options1="speed:full, file:printdata.bin"
 usb_ehci: enabled=1, port1=printer, options1="speed:full, file:printdata.bin"
 usb_xhci: enabled=1, port3=printer, options3="speed:full, file:printdata.bin"
 </screen>
+<note><para>
+Please note that this device is a full-speed only device. No other speed should be specified.
+</para></note>
 </para>
 </section>
 
@@ -6450,6 +6471,13 @@ usb_xhci: enabled=1, port1=hub, options1="speed:full, ports:8"
 </screen>
 At startup, no device is attached to this hub. However, after start up, using the 
 runtime interface, a device can be attached to any or all of the ports.
+</para>
+<para>
+Any device attached to this hub (via the runtime interface), must be the same as or less than the hub's current speed (which is currently only full-speed). Any device plugged into a hub, no matter its max speed, can only function at or below the speed of the hub it is attached to.
+</para>
+<note><para>
+Please note that this device is a full-speed only device. No other speed should be specified.
+</para></note>
 </para>
 </section>
 
@@ -8163,7 +8191,7 @@ This is a Windows Dialog based utility, with source, and includes the following 
 </para></listitem>
 <listitem><para>
         Inserting, extracting, and deleting files from said file systems.
-        (some file system support is currently only read-only)
+        (some file system support is currently read-only)
 </para></listitem>
 <listitem><para>
         Checking the integrity of said file systems and other items.
@@ -10544,7 +10572,7 @@ issues are reported in the next sections.
 <listitem><para>
 First of all, you need the installation media or image (floppy/CD/DVD).
 For platforms that don't support raw device access it might be necessary to
-create an image from the media. You must read the message regarding software
+create an image from the media. Please read the message regarding software
 licenses in <xref linkend="thirdparty"> before you install or use a commercial
 guest operating system in Bochs.
 </para></listitem>
@@ -10761,7 +10789,7 @@ Known problems
 </section>
 
  <section id="guest-dos"><title>DOS</title>
-<para>You must read the message regarding software licenses in
+<para>Please read the message regarding software licenses in
 <xref linkend="thirdparty"> before you install or use MS-DOS, DR-DOS, FreeDOS or
 any other DOS as a guest operating system in Bochs.</para>
 <section><title>Accessing your CD-ROM</title>
@@ -10829,10 +10857,52 @@ hard disk instead of the floppy.
 </section>
 </section>
 
+<section id="guest-win95">
+        <title>Windows 95</title>
+<para>Contributed by Benjamin David Lunt</para>
+<para>Please read the message regarding software licenses in <xref linkend="thirdparty"> before you install Windows 95 as a guest operating system in Bochs.</para>
+<para>
+Windows 95 has been reported to install from the CD-ROM, and run inside Bochs.
+Here are a few settings that seem to work well when running on a Windows10 host, running at 3.0Ghz.
+<screen>
+romimage: file=D:/path/to/your/bios/BIOS-bochs-latest
+cpu: model=broadwell_ult
+cpu: count=1, ips=50000000, reset_on_triple_fault=1, ignore_bad_msrs=1
+cpu: cpuid_limit_winnt=0
+clock: sync=realtime, time0=local
+memory: guest=512, host=512
+vgaromimage: file=D:/path/to/your/bios/VGABIOS-lgpl-latest-cirrus
+vga: extension=cirrus, update_freq=5
+pci: enabled=1, chipset=i440fx, slot1=cirrus
+</screen>
+</para>
+</section>
+
+<section id="guest-win98">
+        <title>Windows 98SE</title>
+<para>Contributed by Benjamin David Lunt</para>
+<para>Please read the message regarding software licenses in <xref linkend="thirdparty"> before you install Windows 98 as a guest operating system in Bochs.</para>
+<para>
+Windows 98SE has been reported to install from the CD-ROM, and run inside Bochs.
+Here are a few settings that seem to work well when running on a Windows10 host, running at 3.0Ghz.
+<screen>
+romimage: file=D:/path/to/your/bios/BIOS-bochs-latest
+cpu: model=corei7_haswell_4770
+cpu: count=1, ips=55000000, reset_on_triple_fault=1, ignore_bad_msrs=1
+cpu: cpuid_limit_winnt=0
+clock: sync=realtime, time0=local
+memory: guest=512, host=512
+vgaromimage: file=D:/path/to/your/bios/VGABIOS-lgpl-latest-cirrus
+vga: extension=cirrus, update_freq=5
+pci: enabled=1, chipset=i440fx, slot1=cirrus
+</screen>
+</para>
+</section>
+
 <section id="guest-winnt4">
         <title>Windows NT 4.0</title>
 <para>
-You must read the message regarding software licenses in
+Please read the message regarding software licenses in
 <xref linkend="thirdparty"> before you install Windows NT 4.0 as a guest operating system in Bochs.
 </para>
 <para>
@@ -10872,7 +10942,7 @@ cpuid: cpuid_limit_winnt=1
 
 <section id="guest-win2k">
         <title>Windows 2000 / Windows 2000 Server</title>
-<para>You must read the message regarding software licenses in
+<para>Please read the message regarding software licenses in
 <xref linkend="thirdparty"> before you install Windows 2000 / Windows 2000 Server as a guest operating system in Bochs.</para>
         <para>
         </para>
@@ -10880,20 +10950,112 @@ cpuid: cpuid_limit_winnt=1
 
 <section id="guest-winxp">
         <title>Windows XP</title>
-<para>You must read the message regarding software licenses in
+<para>Contributed by Benjamin David Lunt</para>
+<para>Please read the message regarding software licenses in
 <xref linkend="thirdparty"> before you install Windows XP as a guest operating system in Bochs.</para>
-        <para>
-        Windows XP has been reported to install from the CD-ROM, and run inside Bochs.
-        The only known issue is to set the IPS to, at least, a value of 10000000.
-        </para>
+<para>
+Windows XP has been reported to install from the CD-ROM, and run inside Bochs.
+Here are a few settings that seem to work well when running on a Windows10 host, running at 3.0Ghz.
+<screen>
+romimage: file=D:/path/to/your/bios/BIOS-bochs-latest
+cpu: model=broadwell_ult
+cpu: count=1, ips=75000000, reset_on_triple_fault=1, ignore_bad_msrs=1
+cpu: cpuid_limit_winnt=0
+clock: sync=realtime, time0=local
+memory: guest=512, host=512
+vgaromimage: file=D:/path/to/your/bios/VGABIOS-lgpl-latest-cirrus
+vga: extension=cirrus, update_freq=5
+pci: enabled=1, chipset=i440fx, slot1=cirrus
+</screen>
+A known issue is to set the IPS value to less than 10,000,000 (minus the commas). WinXP doesn't
+run well at an IPS setting less than 10Mips.
+</para>
+<para>
+Also don't set it to more than 250,000,000. Anything faster and WinXP seems to stall within the CPU loop function. WinXP seems to work well with an IPS setting of 75,000,000 on a 3.0Ghz host.
+</para>
+<para>
+The 64-bit version of WinXP needs Bochs compiled with ACPI support even though you only set to one CPU.
+</para>
+<para>
+For some reason, writing to a USB disk in WinXP, where the write takes a little while, WinXP will think it is an error since it didn't complete fast enough, displaying the error.  I don't know why.
+</para>
 </section>
 
 <section id="guest-win7">
         <title>Windows 7</title>
-<para>You must read the message regarding software licenses in
+<para>Contributed by Benjamin David Lunt</para>
+<para>Please read the message regarding software licenses in
 <xref linkend="thirdparty"> before you install Windows 7 as a guest operating system in Bochs.</para>
-        <para>
-        </para>
+Windows 7 has been reported to install from the CD-ROM, and run inside Bochs.
+Here are a few settings that seem to work well when running on a Windows10 host, running at 3.0Ghz.
+<screen>
+romimage: file=D:/path/to/your/bios/BIOS-bochs-latest
+cpu: model=broadwell_ult
+cpu: count=1, ips=100000000, reset_on_triple_fault=1, ignore_bad_msrs=1
+cpu: cpuid_limit_winnt=0
+clock: sync=realtime, time0=local
+memory: guest=1024, host=1024
+vgaromimage: file=D:/path/to/your/bios/VGABIOS-lgpl-latest-cirrus
+vga: extension=cirrus, update_freq=5
+pci: enabled=1, chipset=i440fx, slot1=cirrus
+</screen>
+</para>
+<para>
+Don't set it to more than 250,000,000. Anything faster and Win7 seems to be sluggish, but seems to work well with an IPS setting of 100,000,000 on a 3.0Ghz host.
+</para>
+</section>
+
+<section id="guest-win8">
+        <title>Windows 8</title>
+<para>Contributed by Benjamin David Lunt</para>
+<para>Please read the message regarding software licenses in
+<xref linkend="thirdparty"> before you install Windows 8 as a guest operating system in Bochs.</para>
+Windows 8 has been reported to install from the CD-ROM, and run inside Bochs.
+Here are a few settings that seem to work well when running on a Windows10 host, running at 3.0Ghz.
+<screen>
+romimage: file=D:/path/to/your/bios/BIOS-bochs-latest
+cpu: model=broadwell_ult
+cpu: count=1, ips=150000000, reset_on_triple_fault=1, ignore_bad_msrs=1
+cpu: cpuid_limit_winnt=0
+clock: sync=realtime, time0=local
+memory: guest=2048, host=2048
+vgaromimage: file=D:/path/to/your/bios/VGABIOS-lgpl-latest-cirrus
+vga: extension=cirrus, update_freq=5
+pci: enabled=1, chipset=i440fx, slot1=cirrus
+</screen>
+</para>
+<para>
+Don't set it to more than 250,000,000. Anything faster and Win8 seems to be sluggish, but seems to work well with an IPS setting of 150,000,000 on a 3.0Ghz host.
+</para>
+</section>
+
+<section id="guest-win10">
+        <title>Windows 10</title>
+<para>Contributed by Benjamin David Lunt</para>
+<para>Please read the message regarding software licenses in
+<xref linkend="thirdparty"> before you install Windows 10 as a guest operating system in Bochs.</para>
+Windows 10 has been reported to install from the CD-ROM, and run inside Bochs, though a few hacks where used to do so. For more information, see <ulink url="https://sourceforge.net/p/bochs/discussion/39592/thread/4f526dc9/">this thread</ulink>.
+</para>
+<para>
+I used another emulator to successfully install Windows 10. Then using Bochs, after a considerable amount of time and a few reboots, I finally got Win10 to boot and load in Bochs.
+</para>
+<para>
+Here are the settings I used when running on a Windows10 host, running at 3.0Ghz.
+<screen>
+romimage: file=D:/path/to/your/bios/BIOS-bochs-latest
+cpu: model=corei7_sandy_bridge_2600k
+cpu: count=1, ips=325000000, reset_on_triple_fault=1, ignore_bad_msrs=1
+cpu: cpuid_limit_winnt=0
+clock: sync=realtime, time0=local
+memory: guest=2048, host=2048
+vgaromimage: file=D:/path/to/your/bios/VGABIOS-lgpl-latest-cirrus
+vga: extension=cirrus, update_freq=5
+pci: enabled=1, chipset=i440fx, slot1=cirrus
+</screen>
+</para>
+<note><para>
+If you use an IPS value less than 325,000,000, Win10 will BSOD and want you to reboot (Assuming a host at 3.0Ghz).
+</para></note>
 </section>
 
 <section id="guest-osr5">
@@ -10903,7 +11065,7 @@ Contributed by Carl Sopchak
 </para>
 
 <para>
-You must read the message regarding software licenses in
+Please read the message regarding software licenses in
 <xref linkend="thirdparty"> before you install SCO OpenServer 5.0.5 as a guest operating system in Bochs.
 </para>
 

--- a/bochs/iodev/usb/scsi_device.cc
+++ b/bochs/iodev/usb/scsi_device.cc
@@ -8,6 +8,7 @@
 //  Based on code by Fabrice Bellard
 //
 //  Written by Paul Brook
+//  Updated and added to by Benjamin D Lunt (fys [at] fysnet [dot] net)
 //
 //  Copyright (C) 2007-2023  The Bochs Project
 //
@@ -84,11 +85,14 @@ scsi_device_t::scsi_device_t(device_image_t *_hdimage, int _tcq,
   hdimage = _hdimage;
   requests = NULL;
   sense = 0;
+  asc = 0;
+  ascq = 0;
   tcq = _tcq;
   completion = _completion;
   dev = _dev;
   block_size = hdimage->sect_size;
   locked = 0;
+  read_only = 0;
   inserted = 1;
   max_lba = (hdimage->hd_size / block_size) - 1;
   curr_lba = max_lba;
@@ -108,11 +112,14 @@ scsi_device_t::scsi_device_t(cdrom_base_c *_cdrom, int _tcq,
   hdimage = NULL;
   requests = NULL;
   sense = 0;
+  asc = 0;
+  ascq = 0;
   tcq = _tcq;
   completion = _completion;
   dev = _dev;
   block_size = 2048;
   locked = 0;
+  read_only = 1;
   inserted = 0;
   max_lba = 0;
   curr_lba = 0;
@@ -156,7 +163,10 @@ void scsi_device_t::register_state(bx_list_c *parent, const char *name)
 {
   bx_list_c *list = new bx_list_c(parent, name, "");
   BXRS_DEC_PARAM_SIMPLE(list, sense);
+  BXRS_DEC_PARAM_SIMPLE(list, asc);
+  BXRS_DEC_PARAM_SIMPLE(list, ascq);
   BXRS_PARAM_BOOL(list, locked, locked);
+  BXRS_PARAM_BOOL(list, read_only, read_only);
   BXRS_DEC_PARAM_SIMPLE(list, curr_lba);
   bx_param_bool_c *requests = new bx_param_bool_c(list, "requests", NULL, NULL, 0);
   requests->set_sr_handlers(this, scsireq_save_handler, scsireq_restore_handler);
@@ -364,11 +374,13 @@ void scsi_device_t::restore_requests(const char *path)
 
 // SCSI command implementation
 
-void scsi_device_t::scsi_command_complete(SCSIRequest *r, int status, int _sense)
+void scsi_device_t::scsi_command_complete(SCSIRequest *r, int status, Bit8u _sense, Bit8u _asc, Bit8u _ascq)
 {
   Bit32u tag;
-  BX_DEBUG(("command complete tag=0x%x status=%d sense=%d", r->tag, status, sense));
+  BX_DEBUG(("command complete tag=0x%x status=%d sense=%d/%d/%d", r->tag, status, _sense, _asc, _ascq));
   sense = _sense;
+  asc = _asc;
+  ascq = _ascq;
   tag = r->tag;
   scsi_remove_request(r);
   completion(dev, SCSI_REASON_DONE, tag, status);
@@ -391,7 +403,7 @@ void scsi_device_t::scsi_read_complete(void *req, int ret)
   if (ret) {
     BX_ERROR(("IO error"));
     completion(r, SCSI_REASON_DATA, r->tag, 0);
-    scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_NO_SENSE);
+    scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_NO_SENSE, 0, 0);
     return;
   }
   BX_DEBUG(("data ready tag=0x%x len=%d", r->tag, r->buf_len));
@@ -415,7 +427,7 @@ void scsi_device_t::scsi_read_data(Bit32u tag)
   }
   BX_DEBUG(("read sector_count=%d", r->sector_count));
   if (r->sector_count == 0) {
-    scsi_command_complete(r, STATUS_GOOD, SENSE_NO_SENSE);
+    scsi_command_complete(r, STATUS_GOOD, SENSE_NO_SENSE, 0, 0);
     return;
   }
   if ((r->async_mode) && (r->seek_pending == 2)) {
@@ -432,12 +444,12 @@ void scsi_device_t::scsi_write_complete(void *req, int ret)
 
   if (ret) {
     BX_ERROR(("IO error"));
-    scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+    scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, 0, 0);
     return;
   }
 
   if (r->sector_count == 0) {
-    scsi_command_complete(r, STATUS_GOOD, SENSE_NO_SENSE);
+    scsi_command_complete(r, STATUS_GOOD, SENSE_NO_SENSE, 0, 0);
   } else {
     len = r->sector_count * block_size;
     if (len > SCSI_DMA_BUF_SIZE) {
@@ -471,7 +483,7 @@ void scsi_device_t::scsi_write_data(Bit32u tag)
     }
   } else {
     BX_ERROR(("CD-ROM: write not supported"));
-    scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+    scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, 0, 0);
   }
 }
 
@@ -494,7 +506,8 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
   Bit8u command;
   Bit8u *outbuf;
   SCSIRequest *r;
-
+  Bit8u _sense = SENSE_NO_SENSE, _asc = 0, _ascq = 0; // assume good return
+  
   command = buf[0];
   r = scsi_find_request(tag);
   if (r) {
@@ -530,6 +543,8 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
         break;
     default:
         BX_ERROR(("Unsupported command length, command %x", command));
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x1A; // Parameter List Length Error
         goto fail;
   }
 
@@ -537,13 +552,23 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
   // some hardware may fail if the command length byte isn't correct.
   if (cmdlen != cmd_len) {
     BX_ERROR(("Sent command length (%d) doesn't match expected command length (%d).", cmd_len, cmdlen));
+#if SCSI_STRICT_CDB
+    _sense = SENSE_ILLEGAL_REQUEST;
+    _asc = 0x1A; // Parameter List Length Error
     goto fail;
+#endif
   }
 
-  if (lun || buf[1] >> 5) {
-    BX_ERROR(("unimplemented LUN %d", lun ? lun : buf[1] >> 5));
-    if ((command != 0x03) && (command != 0x12)) // REQUEST SENSE and INQUIRY
+#if SCSI_OBSOLUTE_LUN
+  if (lun == 0) lun = (buf[1] >> 5);
+#endif
+  if (lun) {
+    BX_ERROR(("unimplemented LUN %d (%d)", lun, buf[1] >> 5));
+    if ((command != 0x03) && (command != 0x12)) { // REQUEST SENSE and INQUIRY
+      _sense = SENSE_ILLEGAL_REQUEST;
+      _asc = 0x21; // LUN out of range
       goto fail;
+    }
   }
   switch (command) {
     case 0x00:
@@ -552,244 +577,313 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
         goto notready;
       break;
     case 0x03:
+      // SPC4r18, section 6.29, page 353
+      // SPC4r18, section 4.5.3, page 61
       BX_DEBUG(("request Sense (len %d)", len));
-      if (len < 4)
-        goto fail;
-      memset(outbuf, 0, 4);
-      r->buf_len = 4;
-      if ((sense == SENSE_NOT_READY) && (len >= 18)) {
-        memset(outbuf, 0, 18);
-        r->buf_len = 18;
-        outbuf[7] = 10;
-        /* asc 0x3a, ascq 0: Medium not present */
-        outbuf[12] = 0x3a;
-        outbuf[13] = 0;
-      }
-      outbuf[0] = 0xf0;
-      outbuf[1] = 0;
-      outbuf[2] = sense;
+      if (len != 252)
+        BX_DEBUG(("SPC-4 recommends that the length be equal to 252."));
+      if ((buf[1] & 1) && (len < 18))
+        BX_DEBUG(("SPC-4 recommends that the length be at least 18 if the DESC bit is set."));
+
+      outbuf[ 0] = (0<<7) | 0x70; // the INFORMATION field is not valid + 0x70
+      outbuf[ 1] = 0;  // obsolete
+      outbuf[ 2] = sense & 0x0F;
+      outbuf[ 3] = 0;  // INFORMATION (MSB)
+      outbuf[ 4] = 0;  // INFORMATION
+      outbuf[ 5] = 0;  // INFORMATION
+      outbuf[ 6] = 0;  // INFORMATION (LSB)
+      outbuf[ 7] = 10; // 10 more bytes after this one
+      outbuf[ 8] = 0;  // Command Specific information (MSB)
+      outbuf[ 9] = 0;  // Command Specific information
+      outbuf[10] = 0;  // Command Specific information
+      outbuf[11] = 0;  // Command Specific information (LSB)
+      outbuf[12] = asc;  // additional sense code
+      outbuf[13] = ascq; // additional sense code qualifier
+      outbuf[14] = 0;  // Field Replaceable Unit Code
+      outbuf[15] = 0;  // SKSV + Sense key specific (MSB)
+      outbuf[16] = 0;  // Sense key specific
+      outbuf[17] = 0;  // Sense key specific (LSB)
+      r->buf_len = 18;
+
+      // if 'sense' was not SENSE_NO_SENSE, we need to set it to SENSE_RECOVERY_ERROR
+      // if 'sense' was SENSE_RECOVERY_ERROR, we can now set it to SENSE_NO_SENSE
+      sense = (sense > SENSE_RECOVERED_ERROR) ? SENSE_RECOVERED_ERROR : SENSE_NO_SENSE;
       break;
     case 0x12:
       BX_DEBUG(("inquiry (len %d)", len));
-      if (buf[1] & 0x2) {
+      if (buf[1] & 0x2) { // obsolete after SPC-2
         // Command support data - optional, not implemented
-        BX_ERROR(("optional INQUIRY command support request not implemented"));
+        BX_ERROR(("SPC-2: optional INQUIRY command support request not implemented. Obsolete after SPC-2"));
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x24; // Invalid Field in CDB
         goto fail;
-      } else if (buf[1] & 0x1) {
-        // Vital product data
+      } 
+      
+      // Vital product data
+      if (buf[1] & 0x1) {
         Bit8u page_code = buf[2];
         if (len < 4) {
           BX_ERROR(("Error: Inquiry (EVPD[%02X]) buffer size %d is less than 4", page_code, len));
+          _sense = SENSE_ILLEGAL_REQUEST;
+          _asc = 0x26; // Parameter Value Invalid
           goto fail;
         }
+        // mandatory page_codes are listed in SPC-4, section 7.7.1, p551
         switch (page_code) {
+          // SPC-4, section 7.7.12, p581
           case 0x00:
             // Supported page codes, mandatory
             BX_DEBUG(("Inquiry EVPD[Supported pages] buffer size %d", len));
-
-            r->buf_len = 0;
-
-            if (type == SCSIDEV_TYPE_CDROM) {
-              outbuf[r->buf_len++] = 5;
-            } else {
-              outbuf[r->buf_len++] = 0;
-            }
-
-            outbuf[r->buf_len++] = 0x00; // this page
-            outbuf[r->buf_len++] = 0x00;
-            outbuf[r->buf_len++] = 3;    // number of pages
-            outbuf[r->buf_len++] = 0x00; // list of supported pages (this page)
-            outbuf[r->buf_len++] = 0x80; // unit serial number
-            outbuf[r->buf_len++] = 0x83; // device identification
+            outbuf[ 0] = (type == SCSIDEV_TYPE_CDROM) ? PERIPHERAL_TYPE_CDROM : PERIPHERAL_TYPE_SBC3;
+            outbuf[ 1] = 0x00; // this page
+            outbuf[ 2] = 0x00; // reserved
+            outbuf[ 3] = 3;    // number of pages supported (count of bytes that follow)
+            // list of supported pages
+            outbuf[ 4] = 0x00; // this page (mandatory)
+            outbuf[ 5] = 0x80; // unit serial number (optional)
+            outbuf[ 6] = 0x83; // device identification (mandatory)
+            r->buf_len = 7;
             break;
-
-          case 0x80:
+            
+          // SPC-4, section 7.7.13, p581
+          case 0x80: // Device serial number, optional
             {
-              int l;
-
-              // Device serial number, optional
-              if (len < 4) {
-                BX_ERROR(("Error: EVPD[Serial number] Inquiry buffer size %d too small, %d needed", len, 4));
-                goto fail;
-              }
-
               BX_DEBUG(("Inquiry EVPD[Serial number] buffer size %d", len));
-              l = BX_MIN(len, (int)strlen(drive_serial_str));
-
-              r->buf_len = 0;
-
-              // Supported page codes
-              if (type == SCSIDEV_TYPE_CDROM) {
-                outbuf[r->buf_len++] = 5;
-              } else {
-                outbuf[r->buf_len++] = 0;
-              }
-
-              outbuf[r->buf_len++] = 0x80; // this page
-              outbuf[r->buf_len++] = 0x00;
-              outbuf[r->buf_len++] = l;
-              memcpy(&outbuf[r->buf_len], drive_serial_str, l);
-              r->buf_len += l;
+              int l = BX_MIN(len - 4, (int) strlen(drive_serial_str));
+              outbuf[ 0] = (type == SCSIDEV_TYPE_CDROM) ? PERIPHERAL_TYPE_CDROM : PERIPHERAL_TYPE_SBC3;
+              outbuf[ 1] = 0x80; // this page
+              outbuf[ 2] = 0x00; // reserved
+              outbuf[ 3] = l;    // length of serial number field
+              memcpy(&outbuf[4], drive_serial_str, l);
+              r->buf_len = 4 + l;
             }
             break;
-
-          case 0x83:
+            
+          // SPC-4, section 7.7.3, p553
+          case 0x83: // Device identification page (mandatory)
             {
-              // Device identification page, mandatory
-              size_t max_len = 255 - 8;
-              size_t id_len = strlen(DEVICE_NAME);
-              if (id_len > max_len)
-                id_len = max_len;
-
               BX_DEBUG(("Inquiry EVPD[Device identification] buffer size %d", len));
-              r->buf_len = 0;
-              if (type == SCSIDEV_TYPE_CDROM) {
-                outbuf[r->buf_len++] = 5;
-              } else {
-                outbuf[r->buf_len++] = 0;
-              }
-
-              outbuf[r->buf_len++] = 0x83; // this page
-              outbuf[r->buf_len++] = 0x00;
-              outbuf[r->buf_len++] = 3 + (Bit8u)id_len;
-
-              outbuf[r->buf_len++] = 0x2; // ASCII
-              outbuf[r->buf_len++] = 0;   // not officially assigned
-              outbuf[r->buf_len++] = 0;   // reserved
-              outbuf[r->buf_len++] = (Bit8u)id_len; // length of data following
-
-              memcpy(&outbuf[r->buf_len], DEVICE_NAME, id_len);
-              r->buf_len += (int)id_len;
+              int l = BX_MIN(255, (int) strlen(DEVICE_NAME));
+              outbuf[ 0] = (type == SCSIDEV_TYPE_CDROM) ? PERIPHERAL_TYPE_CDROM : PERIPHERAL_TYPE_SBC3;
+              outbuf[ 1] = 0x83;  // this page
+              outbuf[ 2] = (Bit8u) (((l + 8) >> 8) & 0xFF); // (MSB)
+              outbuf[ 3] = (Bit8u) (((l + 8) >> 0) & 0xFF); // (LSB)
+              // first designation descriptor
+              outbuf[ 4] = 0x02; // ASCII (SPC-4, Table 23, page 50)
+              outbuf[ 5] = 0;   // not officially assigned
+              outbuf[ 6] = 0;   // reserved
+              outbuf[ 7] = (Bit8u) (l & 0xFF); // length of data following
+              memcpy(&outbuf[8], DEVICE_NAME, l);
+              r->buf_len = 8 + l;
             }
             break;
-
+            
           default:
             BX_ERROR(("Error: unsupported Inquiry (EVPD[%02X]) buffer size %d", page_code, len));
+            _sense = SENSE_ILLEGAL_REQUEST;
+            _asc = 0x26; // Parameter Value Invalid
             goto fail;
         }
-        // done with EVPD
-        break;
+        
+      // Standard INQUIRY data
       } else {
-        // Standard INQUIRY data
+        // EVPD bit is zero, so if the PAGE_CODE field is not zero, error
         if (buf[2] != 0) {
-          BX_ERROR(("Error: Inquiry (STANDARD) page or code is non-zero [%02X]", buf[2]));
+          BX_ERROR(("Error: Inquiry (STANDARD) page_code is non-zero [%02X]", buf[2]));
+          _sense = SENSE_ILLEGAL_REQUEST;
+          _asc = 0x24; // Invalid Field in CDB
           goto fail;
         }
-
-        // PAGE CODE == 0
-        if (len < 5) {
-          BX_ERROR(("Error: Inquiry (STANDARD) buffer size %d is less than 5", len));
-          goto fail;
-        }
-
-        if (len < 36) {
-          BX_ERROR(("Error: Inquiry (STANDARD) buffer size %d is less than 36 (TODO: only 5 required)", len));
-        }
-      }
-
-      if(len > SCSI_MAX_INQUIRY_LEN)
-        len = SCSI_MAX_INQUIRY_LEN;
-      memset(outbuf, 0, len);
-      if (lun || buf[1] >> 5) {
-        outbuf[0] = 0x7f; // LUN not supported
-      } else if (type == SCSIDEV_TYPE_CDROM) {
-        outbuf[0] = 5;
-        outbuf[1] = 0x80;
-        memcpy(&outbuf[16], "BOCHS CD-ROM   ", 16);
-      } else {
-        outbuf[0] = 0;
-        memcpy(&outbuf[16], "BOCHS HARDDISK ", 16);
-      }
-      memcpy(&outbuf[8], "BOCHS  ", 8);
-      memcpy(&outbuf[32], "1.0", 4);
-      // Identify device as SCSI-3 rev 1.
-      // Some later commands are also implemented.
-      outbuf[2] = 3;
-      outbuf[3] = 2; // Format 2
-      outbuf[4] = len - 5; // Additional Length = (Len - 1) - 4
-      // Sync data transfer and TCQ.
-      outbuf[7] = 0x10 | (tcq ? 0x02 : 0);
-      r->buf_len = len;
-      break;
-    case 0x16:
-      BX_INFO(("Reserve(6)"));
-      if (buf[1] & 1)
-        goto fail;
-      break;
-    case 0x17:
-      BX_INFO(("Release(6)"));
-      if (buf[1] & 1)
-        goto fail;
-      break;
-    case 0x1a:
-    case 0x5a:
-      {
-        Bit8u *p;
-        int page;
-
-        page = buf[2] & 0x3f;
-        BX_DEBUG(("mode sense (page %d, len %d)", page, len));
-        p = outbuf;
-        memset(p, 0, 4);
-        outbuf[1] = 0; /* Default media type.  */
-        outbuf[3] = 0; /* Block descriptor length.  */
+        if (len < 36)
+          BX_DEBUG(("Inquiry (STANDARD) buffer size %d is less than the recommended minimum of 36.", len));
+        
         if (type == SCSIDEV_TYPE_CDROM) {
-          outbuf[2] = 0x80; /* Readonly.  */
+          outbuf[ 0] = PERIPHERAL_TYPE_CDROM;
+          outbuf[ 1] = 0x80;
+          memcpy(&outbuf[16], "BOCHS CD-ROM   ", 16);
+        } else {
+          outbuf[ 0] = PERIPHERAL_TYPE_SBC3;
+          outbuf[ 1] = 0;
+          memcpy(&outbuf[16], "BOCHS HARDDISK ", 16);
         }
-        p += 4;
-        if ((page == 4) || (page == 5)) {
-          BX_ERROR(("mode sense: page %d not implemented", page));
-        }
-        if ((page == 8 || page == 0x3f)) {
-          /* Caching page.  */
-          memset(p, 0, 20);
-          p[0] = 8;
-          p[1] = 0x12;
-          p[2] = 4; /* WCE */
-          p += 20;
-        }
-        if ((page == 0x3f || page == 0x2a)
-            && (type == SCSIDEV_TYPE_CDROM)) {
-          /* CD Capabilities and Mechanical Status page. */
-          p[0] = 0x2a;
-          p[1] = 0x14;
-          p[2] = 3; // CD-R & CD-RW read
-          p[3] = 0; // Writing not supported
-          p[4] = 0x7f; /* Audio, composite, digital out,
-                          mode 2 form 1&2, multi session */
-          p[5] = 0xff; /* CD DA, DA accurate, RW supported,
-                          RW corrected, C2 errors, ISRC,
-                          UPC, Bar code */
-          p[6] = 0x2d | (locked ? 2 : 0);
-          /* Locking supported, jumper present, eject, tray */
-          p[7] = 0; /* no volume & mute control, no changer */
-          p[8] = (50 * 176) >> 8; // 50x read speed
-          p[9] = (50 * 176) & 0xff;
-          p[10] = 0 >> 8; // No volume
-          p[11] = 0 & 0xff;
-          p[12] = 2048 >> 8; // 2M buffer
-          p[13] = 2048 & 0xff;
-          p[14] = (16 * 176) >> 8; // 16x read speed current
-          p[15] = (16 * 176) & 0xff;
-          p[18] = (16 * 176) >> 8; // 16x write speed
-          p[19] = (16 * 176) & 0xff;
-          p[20] = (16 * 176) >> 8; // 16x write speed current
-          p[21] = (16 * 176) & 0xff;
-          p += 22;
-        }
-        r->buf_len = (int) (p - outbuf);
-        outbuf[0] = r->buf_len - 4;
-        if (r->buf_len > (int) len)
-          r->buf_len = len;
+        // Identify device as SCSI-3 rev 1.
+        // Some later commands are also implemented.
+        outbuf[2] = 3;  // SPC-1 (4 = SPC-2, 5 = SPC-3)
+        outbuf[3] = 2;  // Format 2 (must be 2)
+        outbuf[4] = 31; // Additional Length
+        outbuf[5] = 0;
+        outbuf[6] = 0;
+        outbuf[7] = 0x10 | (tcq ? 0x02 : 0);  // Sync data transfer and TCQ.
+        memcpy(&outbuf[8], "BOCHS  ", 8);
+        memcpy(&outbuf[32], "1.0", 4);
+        r->buf_len = 36;
       }
       break;
-    case 0x1b:
-      BX_INFO(("Start Stop Unit"));
-      if (type == SCSIDEV_TYPE_CDROM && (buf[4] & 2)) {
-        if (!(buf[4] & 1)) {
-          // eject medium
+    case 0x16: // reserve(6) (SPC-1 only)
+      BX_INFO(("Reserve(6)"));
+      if (buf[1] & 1) { // the Extent is optional
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x26; // Parameter Value Invalid
+        goto fail;
+      } // else do nothing, but return good.
+      break;
+    case 0x17: // release(6) (SPC-1 only)
+      BX_INFO(("Release(6)"));
+      if (buf[1] & 1) { // the Extent is optional
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x26; // Parameter Value Invalid
+        goto fail;
+      } // else do nothing, but return good.
+      break;
+    case 0x56: // reserve(10) (SPC-1 only)
+      BX_INFO(("Reserve(10)"));
+      if (buf[1] & 3) { // the Extent is optional, the LongID is not supported
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x26; // Parameter Value Invalid
+        goto fail;
+      } // else do nothing, but return good.
+      break;
+    case 0x57: // release(10) (SPC-1 only)
+      BX_INFO(("Release(10)"));
+      if (buf[1] & 3) { // the Extent is optional, the LongID is not supported
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x26; // Parameter Value Invalid
+        goto fail;
+      } // else do nothing, but return good.
+      break;
+    case 0x1a:  // mode sense(6)
+    case 0x5a:  // mode sense(10)
+      {
+        Bit8u *p = outbuf;
+        bool llbaa = (buf[1] & (1 << 4)) > 0; // 0 = 8-byte descriptors, 1 = 16-byte descriptors
+        bool dbd = (buf[1] & (1 << 3)) > 0;
+        Bit8u page_code = buf[2] & 0x3F;
+        Bit8u pc = buf[2] >> 6;   // page control (0, 1, 2, or 3)
+        Bit8u sub_page = buf[3];  // sub page code
+        
+        BX_DEBUG(("Mode Sense(%d) (page_code 0x%02X, pc %d, sub_page %d, llbaa %d, dbd %d, len %d)", 
+          (command == 0x1A) ? 6 : 10, page_code, pc, sub_page, llbaa, dbd, len));
+        
+        // if pc == Saved, return error. We don't support saved parameters
+        if (pc == PAGE_CONTROL_SAVED) {
+          BX_ERROR(("Mode Sense(%d): Arborting command. PC == Saved, not supported.", (command == 0x1A) ? 6 : 10));
+          _sense = SENSE_ILLEGAL_REQUEST;
+          _asc = 0x26; // Parameter Value Invalid
+          goto fail;
+        }
+
+        // MMC-6r2f: Section 6.12.1,
+        // Note 17. Since MM Drives do not support sub-pages of mode pages, the Sub-Page field of the MODE SENSE (10) command is ignored by the Drive.
+        if ((type == SCSIDEV_TYPE_CDROM) && (sub_page != 0)) {
+          BX_ERROR(("Mode Sense(%d) sub_page value of 0x%02X is ignored by CD-ROM devices.", (command == 0x1A) ? 6 : 10, sub_page));
+          sub_page = 0;
+        }
+        
+        // MMC-6r2f: Section 6.12.1,
+        // Note 18. Since MM Drives do not support Block Descriptors (see 7.2.1), the LLBAA bit in the MODE SENSE (10) CDB has no meaning and is ignored by the Drive.
+        if ((type == SCSIDEV_TYPE_CDROM) && llbaa) {
+          BX_ERROR(("Mode Sense(%d) llbaa is ignored by CD-ROM devices.", (command == 0x1A) ? 6 : 10));
+          llbaa = 0;
+        }
+        
+        if ((type == SCSIDEV_TYPE_CDROM) && (command == 0x1A)) {
+          // MMC-2 (1999) was that last spec to allow Mode Sense(6)
+          BX_ERROR(("Mode Sense(6) is obsolete for CD-ROM devices. Use Mode Sense(10) instead."));
+        }
+        
+        // create the header
+        if (command == 0x1A) { // mode sense(6)
+          outbuf[0] = 0; // length will be updated later (LSB)
+          outbuf[1] = 0; // Default medium type (type = disk only, reserved in CDROMs)
+          outbuf[2] = ((type == SCSIDEV_TYPE_DISK) && read_only) ? 0x80 : 0x00;  // 0x80 = read only (reserved in CDROMs)
+          outbuf[3] = 0; // Block descriptor length (LSB) (possibly changed below)
+          p += 4;
+        } else {               // mode sense(10)
+          outbuf[0] = 0; // length will be updated later (MSB)
+          outbuf[1] = 0; // length will be updated later (LSB)
+          outbuf[2] = 0; // Default medium type (type = disk only, reserved in CDROMs)
+          outbuf[3] = ((type == SCSIDEV_TYPE_DISK) && read_only) ? 0x80 : 0x00;  // 0x80 = read only (reserved in CDROMs)
+          outbuf[4] = 0; // reserved
+          outbuf[5] = 0; // reserved
+          outbuf[6] = 0; // Block descriptor length (MSB) (possibly changed below)
+          outbuf[7] = 0; // Block descriptor length (LSB)
+          p += 8;
+        }
+        
+        // start of block descriptors
+        //  (remember to update the two fields above)
+        //  (outbuf[3] and outbuf[6 & 7])
+        // (cd-roms do not allow Block Descriptors)
+        if ((type == SCSIDEV_TYPE_DISK) && !dbd) {
+          nb_sectors = (hdimage->hd_size / block_size);
+          if (nb_sectors > 0x00FFFFFF) // don't truncate a large disk
+            nb_sectors = 0;
+          if (!llbaa) {  // 8-byte blocks
+            p[0] = 0x00;    // media density code
+            p[1] = (Bit8u) ((nb_sectors >> 16) & 0xFF);  // number of sectors
+            p[2] = (Bit8u) ((nb_sectors >>  8) & 0xFF);  // number of sectors
+            p[3] = (Bit8u) ((nb_sectors >>  0) & 0xFF);  // number of sectors (LSB)
+            p[4] = 0x00;    // reserved
+            p[5] = (Bit8u) ((block_size >> 16) & 0xFF);  // block size (MSB)
+            p[6] = (Bit8u) ((block_size >>  8) & 0xFF);  // block size
+            p[7] = (Bit8u) ((block_size >>  0) & 0xFF);  // block size (LSB)
+            p += 8;
+            if (command == 0x1A) outbuf[3] = 8;
+            else                 outbuf[7] = 8;
+          } else {  // 16-byte blocks
+            BX_ERROR(("We don't support device specific 16-byte Block Descriptors."));
+          }
+        }
+        
+        // mode pages follow any block descriptors
+        //  if page = 0x3F, return all pages we support from 0 to 3F
+        if (page_code == SENSE_RETURN_ALL) {
+          for (Bit8u i=0; i<SENSE_RETURN_ALL; i++) {
+            p += scsi_do_modepage(p, pc, sub_page, i);
+          }
+        } else {
+          int l = scsi_do_modepage(p, pc, sub_page, page_code);
+          if (l == 0) {
+            _sense = SENSE_ILLEGAL_REQUEST;
+            _asc = 0x24; // Invalid Field in CDB
+            goto fail;
+          } else
+            p += l;
+        }
+
+        r->buf_len = (int) (p - outbuf);
+        if (command == 0x1A) {  // mode sense(6)
+          if (r->buf_len > 256) {
+            BX_ERROR(("Mode Sense(6): return length is more than 256 (%d). Use Mode Sense(10) instead.", r->buf_len));
+          }
+          outbuf[0] = (r->buf_len - sizeof(Bit8u)) & 0xFF;
+        } else {                // mode sense(10)
+          outbuf[0] = ((r->buf_len - sizeof(Bit16u)) >> 8) & 0xFF;
+          outbuf[1] = ((r->buf_len - sizeof(Bit16u)) >> 0) & 0xFF;
+        }
+      }
+      break;
+    case 0x1b: 
+      BX_DEBUG(("Start Stop Unit"));
+      // Start/Stop unit (MMC6r02f, section 6.42, page 574(622)
+      if (type == SCSIDEV_TYPE_CDROM) {
+        // if Power Conditions = 0, and FL = 0, LoEj = 1, and Start = 0, eject the medium
+        if ((buf[4] & 0xF7) == 0x02) {
           cdrom->eject_cdrom();
           inserted = 0;
+        }
+        
+      // Start/Stop unit (SBC-3r25, section 5.23, page 140
+      } else {
+        if ((buf[4] & 4) == 0) {
+          // flush all by simulating a SYNCHRONIZE CACHE(10) (0x35)
+          // or SYNCHRONIZE CACHE(16) (0x91) command
+          // with: SUNC_NV = 0, LBA = 0, and Num Blocks = 0
+          // (both of these commands are 'implemented' below)
+        }
+        // if Power Conditions = 0, and FL = 0, LoEj = 1, and Start = 0, eject the medium
+        if ((buf[4] & 0xF7) == 0x02) {
+          BX_ERROR(("Nothing to eject."));
         }
       }
       break;
@@ -798,7 +892,7 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
       locked = buf[4] & 1;
       break;
     case 0x4a: // SCSI_CD_EVENT_STATUS
-      {
+      if (type == SCSIDEV_TYPE_CDROM) {
         Bit8u Class = 0;
         Bit16u out_len = 4; // the initial header is 4 bytes
         Bit8u *p = &outbuf[4];  // starts at byte 4
@@ -852,9 +946,6 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
               Class = 7;
             }
           }
-          // only send the allocated length requested
-          if (out_len > len)
-            out_len = len;
           
           // out buffer
           // Header is four bytes in length
@@ -866,20 +957,24 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
           outbuf[3] = EVENT_STATUS_MEDIA_REQ;  // supported Event Classes (only event class 4 supported at this time)
         } else { // polled bit
           // we don't (currently) support asynchronous operation.
+          // be sure to modify 'CONFIG_ASYNC' if we support ASYNC
+          _sense = SENSE_ILLEGAL_REQUEST;
+          _asc = 0x24; // Invalid Field in CDB
           goto fail;
         }
+      } else {
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x20; // Invalid Command Opertation code
+        goto fail;
       }
       break;
     case 0x51:  // SCSI_CD_READ_DISC_INFO
-      {
-        Bit16u out_len;
-        
+      if (type == SCSIDEV_TYPE_CDROM) {
         // This code is experimental. may need some help
         BX_DEBUG(("Read Disc Information: Data type requested 0x%02X", buf[1] & 7));
         
-        out_len = (Bit32s) (((Bit32u) buf[7] << 8) | buf[8]);
         switch (buf[1] & DISC_INFO_MASK) {
-          // mmc6r02f.pdf, section 6.21.4, page 379(427) ??
+          // MMC-6r2f, section 6.21.4, page 379(427) ??
           case DISC_INFO_STANDARD: // Standard Disk Information
             outbuf[ 0] = (32 * (0 * 8)) >> 8; // msb length 32 + (8 * number of OPC tables)
             outbuf[ 1] = (32 * (0 * 8)) >> 0; // lsb length
@@ -927,7 +1022,7 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
             // OPC Table entries = 0
             
             // return length
-            r->buf_len = BX_MIN(out_len, (2 + 32) + (0 * 8)); // (len word + sizeof(information)) + (OPC Table Entry count * Size of entry)
+            r->buf_len = (2 + 32) + (0 * 8); // (len word + sizeof(information)) + (OPC Table Entry count * Size of entry)
             break;
           case DISC_INFO_TRACK: // Track Resources Information
             // I am not absolutely sure these are the correct values.
@@ -945,7 +1040,7 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
             outbuf[11] = ((99 >> 0) & 0xFF); // Current number of appendable tracks on disc (LSB)
             
             // return length
-            r->buf_len = BX_MIN(out_len, 12);
+            r->buf_len = 12;
             break;
           case DISC_INFO_POW_RES: // POW Resources Information
             
@@ -955,36 +1050,35 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
             r->buf_len = 0;
             break;
           default:
+            _sense = SENSE_ILLEGAL_REQUEST;
+            _asc = 0x24; // Invalid Field in CDB
             goto fail;
         }
+      } else {
+        // this is XPWRITE(10) in SBC-3r25 (page 188)
+        
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x20; // Invalid Command Opertation code
+        goto fail;
       }
       break;
     case 0x25:
-      BX_DEBUG(("Read Capacity"));
+      BX_DEBUG(("Read Capacity (" FMT_LL "d  %d)", max_lba, block_size));
+      len = 8; // the Read Capacity command does not provide an 'Allocated Length' field
       // The normal LEN field for this command is zero
-      memset(outbuf, 0, 8);
-      if (type == SCSIDEV_TYPE_CDROM) {
-        nb_sectors = max_lba;
-      } else {
-        nb_sectors = hdimage->hd_size / block_size;
-        nb_sectors--;
-      }
-      /* Returned value is the address of the last sector.  */
-      if (nb_sectors) {
-        outbuf[0] = (Bit8u)((nb_sectors >> 24) & 0xff);
-        outbuf[1] = (Bit8u)((nb_sectors >> 16) & 0xff);
-        outbuf[2] = (Bit8u)((nb_sectors >> 8) & 0xff);
-        outbuf[3] = (Bit8u) (nb_sectors & 0xff);
+      // Returned value is the address of the last sector.
+      if (max_lba > 0) {
+        outbuf[0] = (Bit8u)((max_lba >> 24) & 0xff);
+        outbuf[1] = (Bit8u)((max_lba >> 16) & 0xff);
+        outbuf[2] = (Bit8u)((max_lba >> 8) & 0xff);
+        outbuf[3] = (Bit8u) (max_lba & 0xff);
         outbuf[4] = (Bit8u) ((block_size >> 24) & 0xff);
         outbuf[5] = (Bit8u) ((block_size >> 16) & 0xff);
         outbuf[6] = (Bit8u) ((block_size >> 8) & 0xff);
         outbuf[7] = (Bit8u)  (block_size & 0xff);
         r->buf_len = 8;
-      } else {
-      notready:
-        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_NOT_READY);
-        return 0;
-      }
+      } else
+        goto notready;
       break;
     case 0x08:
     case 0x28:
@@ -1021,53 +1115,165 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
       // TODO: flush cache
       break;
     case 0x43:
-      {
-        int start_track, format, msf, toclen = 0;
-
-        if (type == SCSIDEV_TYPE_CDROM) {
-          if (!inserted)
-            goto notready;
-          msf = buf[1] & 2;
-          format = buf[2] & 0xf;
-          start_track = buf[6];
-          BX_DEBUG(("Read TOC (track %d format %d msf %d)", start_track, format, msf >> 1));
-          cdrom->read_toc(outbuf, &toclen, msf, start_track, format);
-          if (toclen > 0) {
-            if (len > toclen)
-              len = toclen;
-            r->buf_len = len;
-            break;
-          }
-          BX_ERROR(("Read TOC error"));
-          goto fail;
+      if (type == SCSIDEV_TYPE_CDROM) {
+        if (!inserted)
+          goto notready;
+        int toclen = 0;
+        int msf = buf[1] & 2;
+        int format = buf[2] & 0xf;
+        int start_track = buf[6];
+        BX_DEBUG(("Read TOC (track %d format %d msf %d)", start_track, format, msf >> 1));
+        cdrom->read_toc(outbuf, &toclen, msf, start_track, format);
+        if (toclen > 0) {
+          if (len > toclen)
+            len = toclen;
+          r->buf_len = len;
         } else {
+          BX_ERROR(("Read TOC error"));
+          _sense = SENSE_ILLEGAL_REQUEST;
+          _asc = 0x24; // Invalid Field in CDB
           goto fail;
         }
+      } else {
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x20; // Invalid Command Opertation code
+        goto fail;
       }
+      break;
     case 0x46:
-      BX_DEBUG(("Get Configuration (rt %d, maxlen %d)", buf[1] & 3, len));
-      memset(outbuf, 0, 8);
-      /* ??? This should probably return much more information.  For now
-         just return the basic header indicating the CD-ROM profile.  */
-      outbuf[7] = 8; // CD-ROM
-      r->buf_len = 8;
-      break;
-    case 0x56:
-      BX_INFO(("Reserve(10)"));
-      if (buf[1] & 3)
+      if (type == SCSIDEV_TYPE_CDROM) {
+        // starting feature number
+        Bit16u start_feature = ((Bit16u) buf[2] << 8) | buf[3];
+        // if rt = 0, then all supported features starting with 'start_feature' are returned
+        // if rt = 1, then all supported features starting with 'start_feature' that have the 'current' bit set, are returned.
+        // if rt = 2, then only the 'start_feature' feature (if supported) will be returned, else only the 8-byte header
+        int rt = buf[1] & 3;
+        
+        BX_DEBUG(("Get Configuration (start 0x%04X, rt %d, maxlen %d)", start_feature, rt, len));
+        
+        Bit8u *p = outbuf;
+        int byte_count = 0;
+        
+        // Header is 8 bytes
+        // bytes 0 -> 3 are updated below
+        outbuf[ 4] = 0;
+        outbuf[ 5] = 0;
+        outbuf[ 6] = (CONFIG_PROFILE_CDROM >> 8) & 0xFF;
+        outbuf[ 7] = (CONFIG_PROFILE_CDROM >> 0) & 0xFF;
+        byte_count += 8; // add the size of this header
+          
+        // Profile List Feature (0x0000) follows the header (offset 8)
+        // MMC-6r2f, section 5.3.1, page 198(246)
+        if (((rt < 2) && (start_feature == CONFIG_FEATURE_0000)) ||
+            ((rt == 2) && (start_feature == CONFIG_FEATURE_0000))) {
+          p = &outbuf[byte_count];
+          p[ 0] = (CONFIG_FEATURE_0000 >> 8) & 0xFF;
+          p[ 1] = (CONFIG_FEATURE_0000 >> 0) & 0xFF;
+          p[ 2] = CONFIG_VERSION(0) | CONFIG_PERSISTENT(1) | CONFIG_CURRENT(1);
+          p[ 3] = 1 * 4;  // count of profiles we support times 4 bytes each (only one, a CD-ROM)
+          // first and only profile
+          p[ 4] = 0;
+          p[ 5] = CONFIG_PROFILE_CDROM;
+          p[ 6] = CONFIG_CURRENT(inserted);  // if CD-ROM is not inserted, this must be 0
+          p[ 7] = 0;
+          // if any more profiles exist, they would go here
+          byte_count += 8; // add the size of this feature
+        }
+          
+        if (inserted) {
+          // Core Feature (0x0001) follows
+          // MMC-6r2f, section 5.3.2, page 201(249)
+          if (((rt < 2) && (start_feature <= CONFIG_FEATURE_0001)) ||
+              ((rt == 2) && (start_feature == CONFIG_FEATURE_0001))) {
+            p = &outbuf[byte_count];
+            p[ 0] = (CONFIG_FEATURE_0001 >> 8) & 0xFF;
+            p[ 1] = (CONFIG_FEATURE_0001 >> 0) & 0xFF;
+            p[ 2] = CONFIG_VERSION(2) | CONFIG_PERSISTENT(1) | CONFIG_CURRENT(1);
+            p[ 3] = 8;  // additional length
+            p[ 4] = (CONFIG_PHY_INT_STND >> 24) & 0xFF;  // Physical Interface Standard (MSB)
+            p[ 5] = (CONFIG_PHY_INT_STND >> 16) & 0xFF;  // 
+            p[ 6] = (CONFIG_PHY_INT_STND >>  8) & 0xFF;  // 
+            p[ 7] = (CONFIG_PHY_INT_STND >>  0) & 0xFF;  // Physical Interface Standard (LSB)
+            p[ 8] = CONFIG_INQ2 | CONFIG_DBE;
+            p[ 9] = 0;
+            p[10] = 0;
+            p[11] = 0;
+            byte_count += 12; // add the size of this feature
+          }
+          
+          // Morphing Feature (0x0002) follows
+          // MMC-6r2f, section 5.3.3, page 203(251)
+          if (((rt < 2) && (start_feature <= CONFIG_FEATURE_0002)) ||
+              ((rt == 2) && (start_feature == CONFIG_FEATURE_0002))) {
+            p = &outbuf[byte_count];
+            p[ 0] = (CONFIG_FEATURE_0002 >> 8) & 0xFF;
+            p[ 1] = (CONFIG_FEATURE_0002 >> 0) & 0xFF;
+            p[ 2] = CONFIG_VERSION(1) | CONFIG_PERSISTENT(1) | CONFIG_CURRENT(1);
+            p[ 3] = 4;  // additional length
+            p[ 4] = CONFIG_OCEVENT | CONFIG_ASYNC;
+            p[ 5] = 0;
+            p[ 6] = 0;
+            p[ 7] = 0;
+            byte_count += 8; // add the size of this feature
+          }
+            
+          // Removable Medium Feature (0x0003) follows
+          // MMC-6r2f, section 5.3.4, page 204(252)
+          if (((rt < 2) && (start_feature <= CONFIG_FEATURE_0003)) ||
+              ((rt == 2) && (start_feature == CONFIG_FEATURE_0003))) {
+            p = &outbuf[byte_count];
+            p[ 0] = (CONFIG_FEATURE_0003 >> 8) & 0xFF;
+            p[ 1] = (CONFIG_FEATURE_0003 >> 0) & 0xFF;
+            p[ 2] = CONFIG_VERSION(2) | CONFIG_PERSISTENT(1) | CONFIG_CURRENT(1);
+            p[ 3] = 4;  // additional length
+            p[ 4] = CONFIG_LOAD_MECH(CONFIG_LM_TRAY) | CONFIG_LOAD(1) | CONFIG_EJECT(1) |
+                      CONFIG_PVNT_JMPR(0) | CONFIG_PVNT_DBML(0) | CONFIG_LOCK(1);
+            p[ 5] = 0;
+            p[ 6] = 0;
+            p[ 7] = 0;
+            byte_count += 8; // add the size of this feature
+          }
+            
+          // Random Readable Feature (0x0010) follows
+          // MMC-6r2f, section 5.3.6, page 208(256)
+          if (((rt < 2) && (start_feature <= CONFIG_FEATURE_0010)) ||
+              ((rt == 2) && (start_feature == CONFIG_FEATURE_0010))) {
+            p = &outbuf[byte_count];
+            p[ 0] = (CONFIG_FEATURE_0010 >> 8) & 0xFF;
+            p[ 1] = (CONFIG_FEATURE_0010 >> 0) & 0xFF;
+            p[ 2] = CONFIG_VERSION(0) | CONFIG_PERSISTENT(1) | CONFIG_CURRENT(1);
+            p[ 3] = 8;  // additional length
+            p[ 4] = ((block_size >> 24) & 0xFF);
+            p[ 5] = ((block_size >> 16) & 0xFF);
+            p[ 6] = ((block_size >>  8) & 0xFF);
+            p[ 7] = ((block_size >>  0) & 0xFF);
+            p[ 8] = 0; // (MSB) one block unit per block_size
+            p[ 9] = 1; // (LSB)
+            p[10] = 0; // reserved
+            p[11] = 0; // reserved
+            byte_count += 12; // add the size of this feature
+          }
+        }  // if(inserted)
+        
+        // Data Length field in the header is total bytes following this field
+        outbuf[0] = (((byte_count - 4) >> 24) & 0xFF); // MSB
+        outbuf[1] = (((byte_count - 4) >> 16) & 0xFF);
+        outbuf[2] = (((byte_count - 4) >>  8) & 0xFF);
+        outbuf[3] = (((byte_count - 4) >>  0) & 0xFF); // LSB
+          
+        r->buf_len = byte_count;
+      } else {  // if (type == SCSIDEV_TYPE_CDROM)
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x20; // Invalid Command Opertation code
         goto fail;
-      break;
-    case 0x57:
-      BX_INFO(("Release(10)"));
-      if (buf[1] & 3)
-        goto fail;
+      }
       break;
     case 0xa0:
+      // MMC-6r02f, section 6.29, page 515(563)
+      // SPC-4r18, section 6.23, page 336
       BX_INFO(("Report LUNs (len %d)", len));
-      if (len < 16)
-        goto fail;
       memset(outbuf, 0, 16);
-      outbuf[3] = 8;
+      outbuf[3] = 8;  // 8 more bytes after this 8-byte header
       r->buf_len = 16;
       break;
     case 0x2f:
@@ -1076,66 +1282,49 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
         goto illegal_lba;
       if (buf[1] & 2) {
         BX_ERROR(("Verify with ByteChk not implemented yet"));
+        _sense = SENSE_ILLEGAL_REQUEST;
+        _asc = 0x24; // Invalid Field in CDB
         goto fail;
       }
       break;
-    case 0x23: {
+    case 0x23:
       // USBMASS-UFI10.pdf  rev 1.0  Section 4.10
-      BX_INFO(("READ FORMAT CAPACITIES (MMC)"));
-
-      unsigned len = (buf[7]<<8) | buf[8];
-#define OUR_LEN  12
-
+      BX_INFO(("READ FORMAT CAPACITIES"));
+      
       // Cap List Header
       outbuf[0] = 0;
       outbuf[1] = 0;
       outbuf[2] = 0;
-      outbuf[3] = OUR_LEN;
-
+      outbuf[3] = 12;
+      
       // Current/Max Cap Header
-      if (type == SCSIDEV_TYPE_CDROM) {
-        nb_sectors = max_lba;
-      } else {
-        nb_sectors = (hdimage->hd_size / block_size);
-        nb_sectors--;
-      }
-      /* Returned value is the address of the last sector.  */
-      outbuf[4] = (Bit8u)((nb_sectors >> 24) & 0xff);
-      outbuf[5] = (Bit8u)((nb_sectors >> 16) & 0xff);
-      outbuf[6] = (Bit8u)((nb_sectors >> 8) & 0xff);
-      outbuf[7] = (Bit8u)(nb_sectors & 0xff);
-      outbuf[8] = 2; // formatted (1 = unformatted)
-      outbuf[9] = 0;
-      outbuf[10] = (block_size >> 8);
-      outbuf[11] = 0;
-
-      r->buf_len = (len < OUR_LEN) ? len : OUR_LEN;
-
-      }
+      // Returned value is the address of the last sector.
+      outbuf[ 4] = (Bit8u) ((max_lba >> 24) & 0xFF);
+      outbuf[ 5] = (Bit8u) ((max_lba >> 16) & 0xFF);
+      outbuf[ 6] = (Bit8u) ((max_lba >>  8) & 0xFF);
+      outbuf[ 7] = (Bit8u) ((max_lba >>  0) & 0xFF);
+      outbuf[ 8] = 2; // formatted (1 = unformatted)
+      outbuf[ 9] = (Bit8u) ((block_size >> 16) & 0xFF);
+      outbuf[10] = (Bit8u) ((block_size >>  8) & 0xFF);
+      outbuf[11] = (Bit8u) ((block_size >>  0) & 0xFF);
+      r->buf_len = 12;
       break;
     // The 0x9E command uses a service action code (ex: 0x9E/0x10)
     case 0x9E:
       switch (buf[1] & 0x1F) { // service action code
         case 0x10: // Read Capacity(16)
           BX_DEBUG(("Read Capacity 16"));
-          memset(outbuf, 0, 32);
-          if (type == SCSIDEV_TYPE_CDROM) {
-            nb_sectors = max_lba;
-          } else {
-            nb_sectors = hdimage->hd_size / block_size;
-            nb_sectors--;
-          }
-          /* Returned value is the address of the last sector.  */
-          if (nb_sectors) {
+          // Returned value is the address of the last sector.
+          if (max_lba) {
             // 64-bit lba
-            outbuf[ 0] = (Bit8u)((nb_sectors >> 56) & 0xff);
-            outbuf[ 1] = (Bit8u)((nb_sectors >> 48) & 0xff);
-            outbuf[ 2] = (Bit8u)((nb_sectors >> 40) & 0xff);
-            outbuf[ 3] = (Bit8u)((nb_sectors >> 32) & 0xff);
-            outbuf[ 4] = (Bit8u)((nb_sectors >> 24) & 0xff);
-            outbuf[ 5] = (Bit8u)((nb_sectors >> 16) & 0xff);
-            outbuf[ 6] = (Bit8u)((nb_sectors >> 8) & 0xff);
-            outbuf[ 7] = (Bit8u) (nb_sectors & 0xff);
+            outbuf[ 0] = (Bit8u)((max_lba >> 56) & 0xff);
+            outbuf[ 1] = (Bit8u)((max_lba >> 48) & 0xff);
+            outbuf[ 2] = (Bit8u)((max_lba >> 40) & 0xff);
+            outbuf[ 3] = (Bit8u)((max_lba >> 32) & 0xff);
+            outbuf[ 4] = (Bit8u)((max_lba >> 24) & 0xff);
+            outbuf[ 5] = (Bit8u)((max_lba >> 16) & 0xff);
+            outbuf[ 6] = (Bit8u)((max_lba >> 8) & 0xff);
+            outbuf[ 7] = (Bit8u) (max_lba & 0xff);
             // 32-bit block size
             outbuf[ 8] = (Bit8u) ((block_size >> 24) & 0xff);
             outbuf[ 9] = (Bit8u) ((block_size >> 16) & 0xff);
@@ -1148,29 +1337,43 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
             // lowest aligned logical block address
             outbuf[14] = 0;
             outbuf[15] = 0;
-            // bytes 16 through 31 are reserved (zero'd above)
-            r->buf_len = (len < 32) ? len : 32;
-          } else {
-            scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_NOT_READY);
-            return 0;
-          }
+            // bytes 16 through 31 are reserved
+            memset(&outbuf[16], 0, 16);
+            r->buf_len = 32;
+          } else
+            goto notready;
           break;
         default:
           BX_ERROR(("Unknown SCSI command (0x9E/%02X)", buf[1] & 0x1F));
       }
       break;
     default:
+      _sense = SENSE_ILLEGAL_REQUEST;
+      _asc = 0x20; // Invalid Command Opertation code
       BX_ERROR(("Unknown SCSI command (0x%02X)", buf[0]));
     fail:
-      scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_ILLEGAL_REQUEST);
+      // Check Condition / Illegal Request / Invalid Field in CDB
+      scsi_command_complete(r, STATUS_CHECK_CONDITION, _sense, _asc, _ascq);
+      return 0;
+    notready:
+      scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_NOT_READY, _asc, _ascq);
       return 0;
     illegal_lba:
-      scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+      scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, _asc, _ascq);
       return 0;
   }
+  
+  // given command was processed successfully, so continue
+  
+  // don't send more than asked for
+  if (r->buf_len > len)
+    r->buf_len = len;
+  
+  // if no data to transfer, signal complete
   if (r->sector_count == 0 && r->buf_len == 0) {
-    scsi_command_complete(r, STATUS_GOOD, SENSE_NO_SENSE);
+    scsi_command_complete(r, STATUS_GOOD, SENSE_NO_SENSE, 0, 0);
   }
+  // else, signal data transfer
   len = r->sector_count * block_size + r->buf_len;
   if (r->write_cmd) {
     return -len;
@@ -1179,6 +1382,343 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
       r->sector_count = (Bit32u) -1;
     return len;
   }
+}
+
+// len = size of data *after* this header
+int scsi_device_t::scsi_do_modepage_hdr(Bit8u *p, Bit8u sub_page, Bit8u page_code, int len) {
+  if (!sub_page) {
+    p[0] = PAGE_SAVEABLE(0) | PAGE_SPF(0) | page_code;
+    p[1] = (Bit8u) len;
+    return 2;
+  } else {
+    p[0] = PAGE_SAVEABLE(0) | PAGE_SPF(1) | page_code;
+    p[1] = sub_page; // subpage_code
+    p[2] = (len >> 8) & 0xFF;  // length of remaining items (MSB)
+    p[3] = (len >> 0) & 0xFF;  // length of remaining items (LSB)
+    return 4;
+  }
+}
+
+// create a page for specified page code
+//  if subpage = 0x00, return all in page_0 format
+//  if subpage = 0xFF, return all (except page 0) in sub_page format
+// if page_code not supported, return 0
+int scsi_device_t::scsi_do_modepage(Bit8u *p, Bit8u pc, Bit8u sub_page, Bit8u page_code) {
+  int size = 0;
+
+  switch (page_code) {
+    case PAGE_VENDOR_SPECIFIC:  // (always in page_0 format)
+      // except for the header, the format of the remaining
+      //  bytes is unspecified, specific to the vendor
+      size = scsi_do_modepage_hdr(p, 0, page_code, 2);
+      p += size;
+      // QEMU says that there is a quirk with an Apple(TM) product
+      //  that needs these values.
+      if (pc == PAGE_CONTROL_CHANGEABLE) {
+        p[0] = 0xFF;
+        p[1] = 0xFF;
+      } else {
+        p[0] = 0x00;
+        p[1] = 0x00;
+      }
+      size += 2;
+      break;
+      
+    case PAGE_ERROR_RECOVERY:  // error recovery page
+      size = scsi_do_modepage_hdr(p, sub_page, page_code, 10);
+      p += size;
+      if (pc == PAGE_CONTROL_CHANGEABLE) {
+        memset(p, 0, 10);
+      } else {
+        if (type == SCSIDEV_TYPE_DISK) {
+          p[ 0] = 0x80;  // AWRE, ARRE, TB, RC, EER, PER, DTE, DCR
+          p[ 1] = 0x20;  // retry count
+          p[ 2] = 0x00;  // correction span in bits
+          p[ 3] = 0x00;  // head offset count
+          p[ 4] = 0x00;  // data strobe offset count
+          p[ 5] = 0x00;  // reserved
+          p[ 6] = 0x00;  // write retry count
+          p[ 7] = 0x00;  // reserved
+          p[ 8] = (0 >>  8) & 0xFF;  // recovery time limit (MSB)
+          p[ 9] = (0 >>  0) & 0xFF;  // recovery time limit (LSB)
+        } else {  // SCSIDEV_TYPE_CDROM
+          p[ 0] = 0x80;  // AWRE, ARRE, TB, RC, EER, PER, DTE, DCR
+          p[ 1] = 0x20;  // retry count
+          p[ 2] = 0x00;  // reserved
+          p[ 3] = 0x00;  // reserved
+          p[ 4] = 0x00;  // reserved
+          p[ 5] = 0x00;  // EMCDR
+          p[ 6] = 0x00;  // write retry count
+          p[ 7] = (0 >> 16) & 0xFF;  // recovery time limit (MSB)
+          p[ 8] = (0 >>  8) & 0xFF;  // recovery time limit
+          p[ 9] = (0 >>  0) & 0xFF;  // recovery time limit (LSB)
+        }
+      }
+      size += 10;
+      break;
+      
+    case PAGE_HD_GEOMETRY:  // rigid disk geometry page (hard drives)
+      if (type == SCSIDEV_TYPE_DISK) {
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 22);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 22);
+        } else {
+          p[ 0] = (hdimage->cylinders >> 16) & 0xFF;  // number of cylinders (MSB)
+          p[ 1] = (hdimage->cylinders >>  8) & 0xFF;  // number of cylinders
+          p[ 2] = (hdimage->cylinders >>  0) & 0xFF;  // number of cylinders (LSB)
+          p[ 3] = 16;                   // number of heads
+          p[ 4] = (hdimage->cylinders >> 16) & 0xFF;  // starting cylinder-write precomp (MSB) (same as num/cyls above)
+          p[ 5] = (hdimage->cylinders >>  8) & 0xFF;  // starting cylinder-write precomp
+          p[ 6] = (hdimage->cylinders >>  0) & 0xFF;  // starting cylinder-write precomp (LSB)
+          p[ 7] = (hdimage->cylinders >> 16) & 0xFF;  // starting cylinder-reduced write (MSB) (same as num/cyls above)
+          p[ 8] = (hdimage->cylinders >>  8) & 0xFF;  // starting cylinder-reduced write
+          p[ 9] = (hdimage->cylinders >>  0) & 0xFF;  // starting cylinder-reduced write (LSB)
+          p[10] = 0;                    // drive step rate (MSB)
+          p[11] = 200;                  // drive step rate (LSB)
+          p[12] = 0xFF;                 // landing zone cylinder (MSB)
+          p[13] = 0xFF;                 // landing zone cylinder
+          p[14] = 0xFF;                 // landing zone cylinder (LSB)
+          p[15] = 0x00;                 // RPL
+          p[16] = 0x00;                 // rotational offset
+          p[17] = 0x00;                 // reserved
+          p[18] = (5400 >>  8) & 0xFF;  // media rotation rate (MSB)  // 5400 to 7200 is common
+          p[19] = (5400 >>  0) & 0xFF;  // media rotation rate (LSB)
+          p[20] = 0x00;                 // reserved
+          p[21] = 0x00;                 // reserved
+        }
+        size += 22;
+      }
+      break;
+      
+  //case PAGE_WRITE_PARAMETERS:    // cdrom: write parameters
+    case PAGE_FLEXIBILE_GEOMETRY:  // disk: flexible disk geometry page
+      if (type == SCSIDEV_TYPE_DISK) {  // PAGE_FLEXIBILE_GEOMETRY
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 30);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 30);
+        } else {
+          p[ 0] = (5000 >> 8) & 0xFF;   // transfer rate (MSB)  // 5000, 2000, 1000, 500, 300, or 250
+          p[ 1] = (5000 >> 0) & 0xFF;   // transfer rate (LSB)  
+          p[ 2] = 2;                    // number of heads
+          p[ 3] = 18;                   // sectors per track
+          p[ 4] = (block_size >> 8) & 0xFF; // bytes per sector (MSB)
+          p[ 5] = (block_size >> 0) & 0xFF; // bytes per sector (LSB)
+          p[ 6] = (hdimage->cylinders >> 8) & 0xFF;   // number of cylinders (MSB)
+          p[ 7] = (hdimage->cylinders >> 0) & 0xFF;   // number of cylinders (LSB)
+          p[ 8] = (hdimage->cylinders >> 16) & 0xFF;  // starting cylinder-write precomp (MSB) (same as num/cyls above to disable)
+          p[ 9] = (hdimage->cylinders >>  0) & 0xFF;  // starting cylinder-write precomp (LSB)
+          p[10] = (hdimage->cylinders >> 16) & 0xFF;  // starting cylinder-reduced write (MSB) (same as num/cyls above to disable)
+          p[11] = (hdimage->cylinders >>  0) & 0xFF;  // starting cylinder-reduced write (LSB)
+          p[12] = 0;                    // drive step rate (MSB) (in 100uS units)
+          p[13] = 1;                    // drive step rate (LSB)
+          p[14] = 1;                    // drive step pulse (in 1uS units)
+          p[15] = 0;                    // head settle delay (MSB) (in 100us units)
+          p[16] = 1;                    // head settle delay (LSB)
+          p[17] = 200;                  // motor on delay  (in 10ths of a second) (200 = 2 seconds)
+          p[18] = 1;                    // motor off delay
+          p[19] = (1 << 6);             // TRDY = 0,  SSN = 1,  MO = 0
+          p[20] = 0x00;                 // SPC
+          p[21] = 0x00;                 // write compensation
+          p[22] = 0x00;                 // head load delay (in mS) (0 = use default setting)
+          p[23] = 0x00;                 // head unload delay (in mS) (0 = use default setting)
+          p[24] = 0;                    // Pin 34   Pin 2
+          p[25] = 0;                    // Pin 4    Pin 1
+          p[26] = (300 >>  8) & 0xFF;   // media rotation rate (MSB) (rotations per minute)
+          p[27] = (300 >>  0) & 0xFF;   // media rotation rate (LSB) (300 for 1.44M, 360 for 1.22M)
+          p[28] = 0x00;                 // reserved
+          p[29] = 0x00;                 // reserved
+        }
+        size += 30;
+        
+      } else { // CDROM: PAGE_WRITE_PARAMETERS
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 50);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 50);
+        } else {
+          p[ 0] = 0x00;                 // BUFE, LS_V, Test Write, Write Type
+          p[ 1] = 0x00;                 // Multi-session, FP, Copy, Track Mode
+          p[ 2] = 0x08;                 // data block type (8 = Mode 1, 2048 block size)
+          p[ 3] = 0x00;                 // link size (valid only if LS_V = 1, and type = "packet/incremental")
+          p[ 4] = 0x00;                 // reserved
+          p[ 5] = 0x00;                 // host application code
+          p[ 6] = 0x00;                 // session format (CD-DA or CD-ROM discs)
+          p[ 7] = 0x00;                 // reserved
+          p[ 8] = (0    >> 24) & 0xFF;  // packet size (MSB) (valid only if FP = 1)
+          p[ 9] = (0    >> 16) & 0xFF;  // packet size
+          p[10] = (0    >>  8) & 0xFF;  // packet size
+          p[11] = (0    >>  0) & 0xFF;  // packet size (LSB)
+          p[12] = (0    >>  8) & 0xFF;  // audio pause length (MSB)
+          p[13] = (0    >>  0) & 0xFF;  // audio pause length (LSB)
+          memset(&p[14], 0, 16);        // media catalog number (only valid for writable CD media)
+          memset(&p[30], 0, 16);        // international standard recording code (only valid for writable CD media)
+          p[46] = 0x00;                 // sub-header byte 0
+          p[47] = 0x00;                 // sub-header byte 1
+          p[48] = 0x00;                 // sub-header byte 2
+          p[49] = 0x00;                 // sub-header byte 3
+        }
+        size += 50;
+      }
+      break;
+      
+    // MMC-6r02f, section 7.5, page 615(663)
+    // SBC-3r25, section 6.4.5, page 217
+    case PAGE_CACHING:  // caching page
+      if (type == SCSIDEV_TYPE_DISK) {
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 18);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 18);
+        } else {
+          p[ 0] = (1<<2) | (0<<0);  // WCE = 1 allow write cache, RCD = 0 allow read cache
+          p[ 1] = 0; // Demand read retention priority, write retention priority
+          p[ 2] = 0; // Disable Pre-fetch transfer length (MSB)
+          p[ 3] = 0; // Disable Pre-fetch transfer length (LSB)
+          p[ 4] = 0; // Minimum Pre-fetch (MSB)
+          p[ 5] = 0; // Minimum Pre-fetch (LSB)
+          p[ 6] = 0; // Maximum Pre-fetch (MSB)
+          p[ 7] = 0; // Maximum Pre-fetch (LSB)
+          p[ 8] = 0; // Maximum Pre-fetch Ceiling (MSB)
+          p[ 9] = 0; // Maximum Pre-fetch Ceiling (LSB)
+          p[10] = 0; // fsw, lbcss, dra, nv_dis
+          p[11] = 0; // Number of cache segments
+          p[12] = 0; // Cache Segment Size (MSB)
+          p[13] = 0; // Cache Segment Size (LSB)
+          p[14] = 0; // reserved
+          p[15] = 0; // obsolete
+          p[16] = 0; // obsolete
+          p[17] = 0; // obsolete
+        }
+      } else {
+        // SCSIDEV_TYPE_CDROM
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 10);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 10);
+        } else {
+          memset(p, 0, 10);
+          p[0] = (1<<2) | (0<<0);  // WCE = 1 allow write cache, RCD = 0 allow read cache
+        }
+        size += 10;
+      }
+      break;
+      
+    case PAGE_POWER_CONDITION: // power condition page
+      size = scsi_do_modepage_hdr(p, sub_page, page_code, 38);
+      p += size;
+      if (pc == PAGE_CONTROL_CHANGEABLE) {
+        memset(p, 0, 38);
+      } else {
+        p[ 0] = 0x00;                  // STANDBY_Y
+        p[ 1] = 0x00;                  // IDLE_C, IDLE_B, IDLE_A, STANDBY_Z
+        p[ 2] = (0x00 >> 24) & 0xFF;   // IDLE_A condition timer (MSB) (valid if IDLE_A = 1)
+        p[ 3] = (0x00 >> 16) & 0xFF;   // IDLE_A condition timer    (100 mS increments)
+        p[ 4] = (0x00 >>  8) & 0xFF;   // IDLE_A condition timer
+        p[ 5] = (0x00 >>  0) & 0xFF;   // IDLE_A condition timer (LSB)
+        p[ 6] = (0x00 >> 24) & 0xFF;   // STANDBY_Z condition timer (MSB) (valid if STANDBY_Z = 1)
+        p[ 7] = (0x00 >> 16) & 0xFF;   // STANDBY_Z condition timer    (100 mS increments)
+        p[ 8] = (0x00 >>  8) & 0xFF;   // STANDBY_Z condition timer
+        p[ 9] = (0x00 >>  0) & 0xFF;   // STANDBY_Z condition timer (LSB)
+        p[10] = (0x00 >> 24) & 0xFF;   // IDLE_B condition timer (MSB) (valid if IDLE_B = 1)
+        p[11] = (0x00 >> 16) & 0xFF;   // IDLE_B condition timer    (100 mS increments)
+        p[12] = (0x00 >>  8) & 0xFF;   // IDLE_B condition timer
+        p[13] = (0x00 >>  0) & 0xFF;   // IDLE_B condition timer (LSB)
+        p[14] = (0x00 >> 24) & 0xFF;   // IDLE_C condition timer (MSB) (valid if IDLE_C = 1)
+        p[15] = (0x00 >> 16) & 0xFF;   // IDLE_C condition timer    (100 mS increments)
+        p[16] = (0x00 >>  8) & 0xFF;   // IDLE_C condition timer
+        p[17] = (0x00 >>  0) & 0xFF;   // IDLE_C condition timer (LSB)
+        p[18] = (0x00 >> 24) & 0xFF;   // STANDBY_Y condition timer (MSB) (valid if STANDBY_Y = 1)
+        p[19] = (0x00 >> 16) & 0xFF;   // STANDBY_Y condition timer    (100 mS increments)
+        p[20] = (0x00 >>  8) & 0xFF;   // STANDBY_Y condition timer
+        p[21] = (0x00 >>  0) & 0xFF;   // STANDBY_Y condition timer (LSB)
+        memset(&p[22], 0, 16);         // reserved
+      }
+      size += 38;
+      break;
+      
+    case PAGE_EXCEPTION_CONTROL: // Information Exceptions Control page
+      size = scsi_do_modepage_hdr(p, sub_page, page_code, 10);
+      p += size;
+      if (pc == PAGE_CONTROL_CHANGEABLE) {
+        memset(p, 0, 10);
+      } else {
+        p[ 0] = 0;                    // PERF  EBF  EWASC  DEXCPT  TEST  EBACKERR  LOGERR
+        p[ 1] = 0;                    // MRIE
+        p[ 2] = (0  >> 24) & 0xFF;    // interval timer (MSB)
+        p[ 3] = (0  >> 16) & 0xFF;    // interval timer   (0x00000000 = vendor specific)
+        p[ 4] = (0  >>  8) & 0xFF;    // interval timer
+        p[ 5] = (0  >>  0) & 0xFF;    // interval timer (LSB)
+        p[ 6] = (0  >> 24) & 0xFF;    // report count (MSB)
+        p[ 7] = (0  >> 16) & 0xFF;    // report count   (0x00000000 = no limit)
+        p[ 8] = (0  >>  8) & 0xFF;    // report count
+        p[ 9] = (0  >>  0) & 0xFF;    // report count (LSB)
+      }
+      size += 10;
+      break;
+      
+    case PAGE_CDVD_INACTIVITY: // CD-ROM inactivity page
+      if (type == SCSIDEV_TYPE_CDROM) {
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 10);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 10);
+        } else {
+          p[ 0] = 0;                    // reserved
+          p[ 1] = 0;                    // reserved
+          p[ 2] = 0;                    // G3Enable  TMOE  DISP  SWPP
+          p[ 3] = 0;                    // reserved
+          p[ 4] = (0  >>  8) & 0xFF;    // Group 1 Min Timeout (seconds) (MSB) (valid only if TMOE = 1)
+          p[ 5] = (0  >>  0) & 0xFF;    // Group 1 Min Timeout (seconds) (LSB)
+          p[ 6] = (0  >>  8) & 0xFF;    // Group 2 Min Timeout (seconds) (MSB)
+          p[ 7] = (0  >>  0) & 0xFF;    // Group 2 Min Timeout (seconds) (LSB)
+          p[ 8] = (0  >>  8) & 0xFF;    // Group 3 Timeout (milliseconds) (MSB) (valid only if G3Enable = 1)
+          p[ 9] = (0  >>  0) & 0xFF;    // Group 3 Timeout (milliseconds) (LSB)
+        }
+        size += 10;
+      }
+      break;
+      
+    // MMC3r10g, section 6.3.11, page 311(347)
+    case PAGE_CAPABILITIES:  // capabilities page
+      if (type == SCSIDEV_TYPE_CDROM) {
+        size = scsi_do_modepage_hdr(p, sub_page, page_code, 24);
+        p += size;
+        if (pc == PAGE_CONTROL_CHANGEABLE) {
+          memset(p, 0, 24);
+        } else {
+          p[ 0] = 0x03;                 // CD-R or CD-RW read/only
+          p[ 1] = 0x00;                 // not writable
+          p[ 2] = 0x7F;                 // Audio, composite, digital out, mode 2, form 1&2, multi session
+          p[ 3] = 0xFF;                 // CD DA, DA accurate, RW supported, RW corrected, C2 error, ISRC, UPC, bar code
+          p[ 4] = 0x2D | (locked ? 2: 0);   // locking supported, jumper present, eject, type = tray
+          p[ 5] = 0x00;                 // no volume & mute control, no changer
+          p[ 6] = 0x00; // obsolete/reserved  // ((50 * 176) >> 8) & 0xFF; // 50x read speed (MSB)
+          p[ 7] = 0x00; // obsolete/reserved  // ((50 * 176) >> 0) & 0xFF; // 50x read speed (LSB)
+          p[ 8] = (0 >> 8) & 0xFF;      // no volume controls (MSB)
+          p[ 9] = (0 >> 0) & 0xFF;      // no volume controls (LSB)
+          p[10] = (2048 >> 16) & 0xFF;  // 2Meg buffer (MSB)
+          p[11] = (2048 >>  0) & 0xFF;  // 2Meg buffer (LSB)
+          p[12] = 0x00; // obsolete/reserved  // ((16 * 176) >> 8) & 0xFF; // 16x read speed current (MSB)
+          p[13] = 0x00; // obsolete/reserved  // ((16 * 176) >> 0) & 0xFF; // 16x read speed current (LSB)
+          p[14] = 0x00;                 // reserved
+          p[15] = 0x00;                 // Length, LSBF, RCK, BCKF
+          p[16] = 0x00;                 // obsolete/reserved
+          p[17] = 0x00;                 // obsolete/reserved
+          p[18] = 0x00;                 // obsolete/reserved
+          p[19] = 0x00;                 // obsolete/reserved
+          p[20] = 0x00;                 // copy management revision supported (MSB)
+          p[21] = 0x00;                 // copy management revision supported (LSB)
+          p[22] = 0x00;                 // reserved
+          p[23] = 0x00;                 // reserved
+        }
+        size += 24;
+      }
+      break;
+  }
+
+  return size;
 }
 
 void scsi_device_t::set_inserted(bool value)
@@ -1245,24 +1785,23 @@ void scsi_device_t::seek_complete(SCSIRequest *r)
         ret = (int) cdrom->read_block(r->dma_buf + (i * 2048), (Bit32u) (r->sector + i), 2048);
       } while ((++i < n) && (ret == 1));
       if (ret == 0) {
-        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_MEDIUM_ERROR);
+        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_MEDIUM_ERROR, 0, 0);
         return;
       }
     } else {
       ret = (int) hdimage->lseek(r->sector * block_size, SEEK_SET);
       if (ret < 0) {
         BX_ERROR(("could not lseek() hard drive image file"));
-        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, 0, 0);
         return;
       }
       i = 0;
       do {
-        ret = (int) hdimage->read((bx_ptr_t) (r->dma_buf + (i * block_size)),
-                                 block_size);
+        ret = (int) hdimage->read((bx_ptr_t) (r->dma_buf + (i * block_size)), block_size);
       } while ((++i < n) && (ret == block_size));
       if (ret != block_size) {
         BX_ERROR(("could not read() hard drive image file"));
-        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, 0, 0);
         return;
       }
     }
@@ -1276,7 +1815,7 @@ void scsi_device_t::seek_complete(SCSIRequest *r)
       ret = (int)hdimage->lseek(r->sector * block_size, SEEK_SET);
       if (ret < 0) {
         BX_ERROR(("could not lseek() hard drive image file"));
-        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, 0, 0);
       }
       i = 0;
       do {
@@ -1285,7 +1824,7 @@ void scsi_device_t::seek_complete(SCSIRequest *r)
       } while ((++i < n) && (ret == block_size));
       if (ret != block_size) {
         BX_ERROR(("could not write() hard drive image file"));
-        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR);
+        scsi_command_complete(r, STATUS_CHECK_CONDITION, SENSE_HARDWARE_ERROR, 0, 0);
         return;
       }
       r->sector += n;

--- a/bochs/iodev/usb/scsi_device.h
+++ b/bochs/iodev/usb/scsi_device.h
@@ -8,6 +8,7 @@
 //  Based on code by Fabrice Bellard
 //
 //  Written by Paul Brook
+//  Updated and added to by Benjamin D Lunt (fys [at] fysnet [dot] net)
 //
 //  Copyright (C) 2007-2023  The Bochs Project
 //
@@ -28,9 +29,24 @@
 #ifndef BX_IODEV_SCSI_DEVICE_H
 #define BX_IODEV_SCSI_DEVICE_H
 
-typedef void (*scsi_completionfn)(void *opaque, int reason, Bit32u tag,
-                                  Bit32u arg);
+typedef void (*scsi_completionfn)(void *opaque, int reason, Bit32u tag, Bit32u arg);
 class cdrom_base_c;
+
+// SCSI-2r10l, section 7.2, page 72(108) states that a LUN is given in bits 7:5
+//  of byte[1] of the command block (CDB). (year 1993)
+// SPC-1r11a, section 4.2, page 10(26) has this field reserved. (year 1997)
+// SPC-3r23f, section 4.3.2, page 23 has this field as "miscellaneous CDB information" (year 2005)
+// If you wish to support this old, now obsolete field, change SCSI_OBSOLUTE_LUN in scsi_device.h
+#define SCSI_OBSOLUTE_LUN  0
+
+// set this to 1 to be strict on CDB parameters.
+// for example, Windows(TM) sends a 12-byte Request Sense CDB, when it should be 6.
+// Windows(TM) also sends a 12-byte Get Configuration CDB, when it should be 10.
+// (setting this to 0 will allow these errors to be ignored)
+#define SCSI_STRICT_CDB  0
+
+#define PERIPHERAL_TYPE_SBC3   0  // magnetic disk
+#define PERIPHERAL_TYPE_CDROM  5  // cd-rom
 
 enum scsidev_type {
   SCSIDEV_TYPE_DISK,
@@ -41,6 +57,34 @@ enum scsi_reason {
   SCSI_REASON_DONE,
   SCSI_REASON_DATA
 };
+
+// SCSI_CD_CONFIGURATION
+#define CONFIG_PROFILE_CDROM          8   // a CD-ROM
+#define CONFIG_PHY_INT_STND  0x00000001   // SCSI Family
+#define CONFIG_CURRENT(c)       ((c)<<0)  // current
+#define CONFIG_PERSISTENT(p)    ((p)<<1)  // persistent
+#define CONFIG_VERSION(v)       ((v)<<2)  // version
+// supported features (MMC-6r2f, section 5.2.3, page 194(242)
+#define CONFIG_FEATURE_0000      0x0000   // optional
+#define CONFIG_FEATURE_0001      0x0001   // mandatory
+  #define CONFIG_INQ2               (0<<1)  // Inquire support (0 = standard, 1 = extra)
+  #define CONFIG_DBE                (0<<0)  // Device Buzy Event (0 = legacy, 1 = includes DBE's)
+#define CONFIG_FEATURE_0002      0x0002   // mandatory
+  #define CONFIG_OCEVENT            (1<<1)  // OCEvent (must be 1)
+  #define CONFIG_ASYNC              (0<<1)  // 0 = supports only the polling implentation of GET EVENT STATUS NOTIFICATION (see 0x4A)
+#define CONFIG_FEATURE_0003      0x0003   // optional
+  #define CONFIG_LOAD_MECH(lm)     ((lm)<<5) // Load Mechanism
+    #define CONFIG_LM_CADDY          0
+    #define CONFIG_LM_TRAY           1
+    #define CONFIG_LM_POPUP          2
+    #define CONFIG_LM_EMB_CHANGE     4
+    #define CONFIG_LM_EMB_CHANGE_MAG 5
+  #define CONFIG_LOAD(l)           ((l)<<4) // Load
+  #define CONFIG_EJECT(e)          ((e)<<3) // Eject
+  #define CONFIG_PVNT_JMPR(pj)    ((pj)<<2) // Prevent Jumper
+  #define CONFIG_PVNT_DBML(d)      ((d)<<1) // Device Busy Class
+  #define CONFIG_LOCK(l)           ((l)<<0) // Lock capable
+#define CONFIG_FEATURE_0010      0x0010   // optional
 
 // SCSI_CD_EVENT_STATUS items
 #define EVENT_STATUS_POLLED       1
@@ -91,14 +135,62 @@ enum scsi_reason {
 #define DISC_INFO_TRACK          1
 #define DISC_INFO_POW_RES        2
 
+// SCSI Page Mode attributes
+#define PAGE_CONTROL_CURRENT     0
+#define PAGE_CONTROL_CHANGEABLE  1
+#define PAGE_CONTROL_DEFAULT     2
+#define PAGE_CONTROL_SAVED       3
 
+#define PAGE_SAVEABLE(s)     ((s)<<7)
+#define PAGE_SPF(s)          ((s)<<6)
 
+// SPC-4r18, section 7.4.5, page 440
+// SPC-4r18, section D.6, page 677
+// SBC-3r25, section 6.4, page 208
+// MMC-6r02f, section 7.2.2, page 597(645)
+// SCSI-r10L, section 9.3.3.7, pages 229(265)
+#define PAGE_VENDOR_SPECIFIC        0x00   
+#define PAGE_ERROR_RECOVERY         0x01   // SBC-3/MMC-6
+#define PAGE_DISCONNECT             0x02   // SBC-3/MMC-6
+#define PAGE_FORMAT_DEVICE          0x03   // SBC-3
+#define PAGE_MRW                    0x03   // MMC-6 (Mount Rainier CD-RW's = CD-MRW)
+#define PAGE_HD_GEOMETRY            0x04   // SBC-3
+#define PAGE_FLEXIBILE_GEOMETRY     0x05   // SBC-3
+#define PAGE_WRITE_PARAMETERS       0x05   // MMC-6
+#define PAGE_VERIFY_ERROR           0x07   // SBC-3
+#define PAGE_CACHING                0x08   // SBC-3/MMC-6
+#define PAGE_CONTROL                0x0A   // SBC-3/MMC-6 (sub pages 0 & 1)
+#define PAGE_MEDIUM_TYPES           0x0B   // SBC-3
+#define PAGE_NOTCH_PARTITION        0x0C   // SBC-3
+#define PAGE_CD_DEVICE_PARAMS       0x0D   // MMC-6
+#define PAGE_CD_AUDIO_CONTROL       0x0E   // MMC-6
+#define PAGE_XOR_CONTROL            0x10   // SBC-3
+#define PAGE_MEDIUM_PARTITION       0x11   // SBC-3
+#define PAGE_ENCLOSURE_SERV_MAN     0x14   // SBC-3/MMC-6
+#define PAGE_PROTOCOL_SPECIFIC_LUN  0x18   // SBC-3/MMC-6
+#define PAGE_PROTOCOL_SPECIFIC_PORT 0x19   // SBC-3/MMC-6
+#define PAGE_POWER_CONDITION        0x1A   // SBC-3/MMC-6
+#define PAGE_EXCEPTION_CONTROL      0x1C   // SBC-3/MMC-6
+#define PAGE_CDVD_INACTIVITY        0x1D   // MMC-6
+#define PAGE_CAPABILITIES           0x2A   // MMC-3
+#define SENSE_RETURN_ALL            0x3F
 
-#define SENSE_NO_SENSE        0
-#define SENSE_NOT_READY       2
-#define SENSE_MEDIUM_ERROR    3
-#define SENSE_HARDWARE_ERROR  4
-#define SENSE_ILLEGAL_REQUEST 5
+// SPC-4r18, Table 41 (page 63)
+// Sense Key:
+#define SENSE_NO_SENSE         0
+#define SENSE_RECOVERED_ERROR  1
+#define SENSE_NOT_READY        2
+#define SENSE_MEDIUM_ERROR     3
+#define SENSE_HARDWARE_ERROR   4
+#define SENSE_ILLEGAL_REQUEST  5
+#define SENSE_UNIT_ATTENTION   6
+#define SENSE_DATA_PROTECT     7
+#define SENSE_BLANK_CHECK      8
+#define SENSE_VENDOR_SPECIFIC  9
+#define SENSE_COPY_ABORTED    10
+#define SENSE_ABORTED_COMMAND 11
+#define SENSE_VOLUME_OVERFLOW 13
+#define SENSE_MISCOMPARE      14
 
 #define STATUS_GOOD            0
 #define STATUS_CHECK_CONDITION 2
@@ -130,7 +222,7 @@ public:
 
   void register_state(bx_list_c *parent, const char *name);
   Bit32s scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, int lun, bool async);
-  void scsi_command_complete(SCSIRequest *r, int status, int sense);
+  void scsi_command_complete(SCSIRequest *r, int status, Bit8u _sense, Bit8u _asc, Bit8u _ascq);
   void scsi_cancel_io(Bit32u tag);
   void scsi_read_complete(void *req, int ret);
   void scsi_read_data(Bit32u tag);
@@ -138,6 +230,8 @@ public:
   void scsi_write_data(Bit32u tag);
   Bit8u* scsi_get_buf(Bit32u tag);
   const char *get_serial_number() {return drive_serial_str;}
+  int scsi_do_modepage_hdr(Bit8u *p, Bit8u sub_page, Bit8u page_code, int len);
+  int scsi_do_modepage(Bit8u *p, Bit8u pc, Bit8u sub_page, Bit8u page_code);
   void set_inserted(bool value);
   bool get_inserted() {return inserted;}
   bool get_locked() {return locked;}
@@ -172,8 +266,9 @@ private:
   bool inserted;
   // members handled by save/restore
   Bit64u curr_lba;
-  int sense;
+  Bit8u sense, asc, ascq;
   bool locked;
+  bool read_only;
   SCSIRequest *requests;
 };
 

--- a/bochs/iodev/usb/uhci_core.cc
+++ b/bochs/iodev/usb/uhci_core.cc
@@ -752,7 +752,7 @@ void bx_uhci_core_c::uhci_timer(void)
           td_count++;
           
           // The UHCI (USB 1.1) only allows so many bytes to be transfered per frame.
-          // Due to control/bulk reclamation, we need to catch this and stop transfering 
+          // Due to control/bulk reclamation, we need to catch this and stop transferring 
           //  or this code will just keep processing TDs.
           bytes_processed += r_actlen;
           if (bytes_processed >= hub.max_bandwidth) {
@@ -835,35 +835,55 @@ void bx_uhci_core_c::uhci_timer(void)
   //    However, since we don't do anything, let's not.
 }
 
-void uhci_event_handler(int event, USBPacket *packet, void *dev, int port)
+int uhci_event_handler(int event, void *ptr, void *dev, int port)
 {
   if (dev != NULL) {
-    ((bx_uhci_core_c *) dev)->event_handler(event, packet, port);
+    return ((bx_uhci_core_c *) dev)->event_handler(event, ptr, port);
   }
+  return -1;
 }
 
-void bx_uhci_core_c::event_handler(int event, USBPacket *packet, int port)
+int bx_uhci_core_c::event_handler(int event, void *ptr, int port)
 {
-  if (event == USB_EVENT_ASYNC) {
-    BX_DEBUG(("Async packet completion"));
-    USBAsync *p = container_of_usb_packet(packet);
-    p->done = 1;
-  } else if (event == USB_EVENT_WAKEUP) {
-    if (hub.usb_port[port].suspend && !hub.usb_port[port].resume) {
-      hub.usb_port[port].resume = 1;
-    }
-    // if in suspend state, signal resume
-    if (hub.usb_command.suspend) {
-      hub.usb_command.resume = 1;
-      hub.usb_status.resume = 1;
-      if (hub.usb_enable.resume) {
-        hub.usb_status.interrupt = 1;
+  int ret = 0;
+  USBAsync *p;
+
+  switch (event) {
+    // packet events start here
+    case USB_EVENT_ASYNC:
+      BX_DEBUG(("Async packet completion"));
+      p = container_of_usb_packet(ptr);
+      p->done = 1;
+      break;
+    case USB_EVENT_WAKEUP:
+      if (hub.usb_port[port].suspend && !hub.usb_port[port].resume) {
+        hub.usb_port[port].resume = 1;
       }
-      update_irq();
-    }
-  } else {
-    BX_ERROR(("unknown/unsupported event (id=%d) on port #%d", event, port+1));
+      // if in suspend state, signal resume
+      if (hub.usb_command.suspend) {
+        hub.usb_command.resume = 1;
+        hub.usb_status.resume = 1;
+        if (hub.usb_enable.resume) {
+          hub.usb_status.interrupt = 1;
+        }
+        update_irq();
+      }
+      break;
+
+    // host controller events start here
+    case USB_EVENT_CHECK_SPEED:
+      if (ptr != NULL) {
+        usb_device_c *usb_device = (usb_device_c *) ptr;
+        if (usb_device->get_speed() <= USB_SPEED_FULL)
+          ret = 1;
+      }
+      break;
+    default:
+      BX_ERROR(("unknown/unsupported event (id=%d) on port #%d", event, port+1));
+      ret = -1; // unknown event, event not handled
   }
+  
+  return ret;
 }
 
 bool bx_uhci_core_c::DoTransfer(Bit32u address, struct TD *td) {
@@ -1040,11 +1060,12 @@ void bx_uhci_core_c::pci_write_handler(Bit8u address, Bit32u value, unsigned io_
   }
 }
 
+// these must match USB_SPEED_*
 const char *usb_speed[4] = {
-  "low",
-  "full",
-  "high",
-  "super"
+  "low",     // USB_SPEED_LOW   = 0
+  "full",    // USB_SPEED_FULL  = 1
+  "high",    // USB_SPEED_HIGH  = 2
+  "super"    // USB_SPEED_SUPER = 3
 };
 
 bool bx_uhci_core_c::set_connect_status(Bit8u port, bool connected)
@@ -1096,7 +1117,6 @@ bool bx_uhci_core_c::set_connect_status(Bit8u port, bool connected)
           BX_INFO(("port #%d: connect: %s", port+1, device->get_info()));
         }
       }
-      device->set_event_handler(this, uhci_event_handler, port);
     } else {
       BX_INFO(("port #%d: device disconnect", port+1));
       hub.usb_port[port].status = 0;

--- a/bochs/iodev/usb/uhci_core.h
+++ b/bochs/iodev/usb/uhci_core.h
@@ -198,7 +198,7 @@ public:
   virtual void set_port_device(int port, usb_device_c *dev);
   virtual void pci_write_handler(Bit8u address, Bit32u value, unsigned io_len);
 
-  void event_handler(int event, USBPacket *packet, int port);
+  int event_handler(int event, void *ptr, int port);
 
 protected:
   bx_uhci_core_t hub;

--- a/bochs/iodev/usb/usb_common.cc
+++ b/bochs/iodev/usb/usb_common.cc
@@ -155,6 +155,8 @@ bool bx_usbdev_ctl_c::init_device(bx_list_c *portconf, logfunctions *hub, void *
   return (*device != NULL);
 }
 
+extern const char *usb_speed[4];
+
 void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portconf)
 {
   const char *raw_options;

--- a/bochs/iodev/usb/usb_common.cc
+++ b/bochs/iodev/usb/usb_common.cc
@@ -131,7 +131,7 @@ void bx_usbdev_ctl_c::list_devices(void)
   }
 }
 
-bool bx_usbdev_ctl_c::init_device(bx_list_c *portconf, logfunctions *hub, void **dev)
+bool bx_usbdev_ctl_c::init_device(bx_list_c *portconf, logfunctions *hub, void **dev, USBCallback *cb, int port)
 {
   Bit8u devtype, modtype;
   usb_device_c **device = (usb_device_c**)dev;
@@ -149,6 +149,7 @@ bool bx_usbdev_ctl_c::init_device(bx_list_c *portconf, logfunctions *hub, void *
   *device = usbdev_locator_c::create(usb_module_names[modtype],
                                      usb_device_names[devtype]);
   if (*device != NULL) {
+    (*device)->set_event_handler(hub, cb, port);
     parse_port_options(*device, portconf);
   }
   return (*device != NULL);
@@ -178,10 +179,6 @@ void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portco
       } else {
         BX_ERROR(("ignoring unknown USB device speed: '%s'", opts[i]+6));
       }
-      if (!device->set_speed(speed)) {
-        BX_PANIC(("USB device '%s' doesn't support '%s' speed",
-                  usb_device_names[devtype], opts[i]+6));
-      }
     } else if (!strcmp(opts[i], "debug")) {
       device->set_debug_mode();
     } else if (!strncmp(opts[i], "pcap:", 5)) {
@@ -195,6 +192,20 @@ void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portco
       free(opts[i]);
       opts[i] = NULL;
     }
+  }
+
+  // let the device code check if the speed is valid for this device.
+  if (!device->set_speed(speed)) {
+    BX_PANIC(("USB device '%s' doesn't support '%s' speed",
+              usb_device_names[devtype], usb_speed[speed]));
+  }
+
+  // let the host controller check if the speed is valid for this device.
+  // -if we are on an xhci, all super-speed devices must be on the first half register sets,
+  //   and all other speeds on the second half register sets.
+  // -if we are on a hub, the speed must match the hub's speed.
+  if (device->hc_event(USB_EVENT_CHECK_SPEED, device) != 1) {
+    BX_PANIC(("Host Controller/Hub returned error with device speed of '%s'.", usb_speed[speed]));
   }
 }
 
@@ -258,10 +269,10 @@ void usbdev_locator_c::cleanup()
 usb_device_c *usbdev_locator_c::create(const char *type, const char *devname)
 {
   usbdev_locator_c *ptr = 0;
-
+  
   for (ptr = all; ptr != NULL; ptr = ptr->next) {
     if (strcmp(type, ptr->type) == 0)
-      return (ptr->allocate(devname));
+      return ptr->allocate(devname);
   }
   return NULL;
 }
@@ -324,6 +335,10 @@ int usb_device_c::handle_packet(USBPacket *p)
       d.remote_wakeup = 0;
       d.addr = 0;
       d.state = USB_STATE_DEFAULT;
+#if HANDLE_TOGGLE_CONTROL
+      for (int i=0; i<USB_MAX_ENDPOINTS; i++)
+        d.endpoint_info[i].toggle = 0;
+#endif
       handle_reset();
       break;
     case USB_TOKEN_SETUP:
@@ -766,15 +781,12 @@ void usb_device_c::usb_dump_packet(Bit8u *data, int size, int bus, int dev_addr,
     return;
   }
 
-  // safety catch
+  // safety catch (only dump up to 8192 bytes per packet so to not fill the log file)
   if (size > 8192) {
     BX_DEBUG(("packet hexdump with irregular size: %u (truncating to 8192 bytes)", size));
+    size = 8192;
   }
   
-  // safety catch (only dump up to 8192 bytes per packet so to not fill the log file)
-  if (size > 8192)
-    size = 8192;
-
   if (getonoff(LOGLEV_DEBUG) == ACT_REPORT) {
     BX_DEBUG(("packet hexdump (%d bytes)", size));
     strcpy(buf_str, "");
@@ -795,7 +807,7 @@ void usb_device_c::usb_dump_packet(Bit8u *data, int size, int bus, int dev_addr,
     }
     if (strlen(buf_str) > 0) BX_DEBUG(("%s", buf_str));
   }
-
+  
   if (d.pcap_mode) {
     d.pcapture.write_packet(data, size, bus, dev_addr, ep, type, is_setup, can_append);
   }

--- a/bochs/iodev/usb/usb_common.cc
+++ b/bochs/iodev/usb/usb_common.cc
@@ -155,7 +155,13 @@ bool bx_usbdev_ctl_c::init_device(bx_list_c *portconf, logfunctions *hub, void *
   return (*device != NULL);
 }
 
-extern const char *usb_speed[4];
+// these must match USB_SPEED_*
+static const char *usb_speed[4] = {
+  "low",     // USB_SPEED_LOW   = 0
+  "full",    // USB_SPEED_FULL  = 1
+  "high",    // USB_SPEED_HIGH  = 2
+  "super"    // USB_SPEED_SUPER = 3
+};
 
 void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portconf)
 {

--- a/bochs/iodev/usb/usb_common.h
+++ b/bochs/iodev/usb/usb_common.h
@@ -53,10 +53,12 @@
 #define USB_RET_IOERROR (-5)
 #define USB_RET_ASYNC   (-6)
 
+// these must remain in this order, 0 -> 3
 #define USB_SPEED_LOW   0
 #define USB_SPEED_FULL  1
 #define USB_SPEED_HIGH  2
 #define USB_SPEED_SUPER 3
+extern const char *usb_speed[4];
 
 #define USB_STATE_NOTATTACHED 0
 #define USB_STATE_ATTACHED    1
@@ -137,14 +139,17 @@
 
 typedef struct USBPacket USBPacket;
 
-#define USB_EVENT_WAKEUP 0
-#define USB_EVENT_ASYNC  1
+// packet events
+#define USB_EVENT_WAKEUP        0
+#define USB_EVENT_ASYNC         1
+// controller events
+#define USB_EVENT_CHECK_SPEED  10
 
 // set this to 1 to monitor the TD's toggle bit
 // setting to 0 will speed up the emualtion slightly
 #define HANDLE_TOGGLE_CONTROL 1
 
-typedef void USBCallback(int event, USBPacket *packet, void *dev, int port);
+typedef int USBCallback(int event, void *ptr, void *dev, int port);
 
 class usb_device_c;
 
@@ -193,7 +198,7 @@ public:
   void exit(void);
   const char **get_device_names(void);
   void list_devices(void);
-  virtual bool init_device(bx_list_c *portconf, logfunctions *hub, void **dev);
+  virtual bool init_device(bx_list_c *portconf, logfunctions *hub, void **dev, USBCallback *cb, int port);
 private:
   void parse_port_options(usb_device_c *dev, bx_list_c *portconf);
 };
@@ -232,6 +237,7 @@ public:
       return 0;
     }
   }
+  int get_min_speed() { return d.minspeed; }
   
   // return information for the specified ep of the current device
 #define USB_MAX_ENDPOINTS   5   // we currently don't use more than 5 endpoints (ep0, ep1, ep2, ep3, and ep4)
@@ -269,8 +275,15 @@ public:
   }
   void set_debug_mode();
   void set_pcap_mode(const char *pcap_name);
-
+  
   void usb_send_msg(int msg);
+
+  // manually invoke a HC event
+  int hc_event(int event, usb_device_c *device) {
+    if (d.event.cb != NULL)
+      return d.event.cb(event, device, d.event.dev, d.event.port);
+    return -1;
+  }
 
 protected:
   struct {
@@ -352,7 +365,7 @@ static BX_CPP_INLINE void usb_cancel_packet(USBPacket *p)
 
 static BX_CPP_INLINE void usb_packet_complete(USBPacket *p)
 {
-    p->complete_cb(USB_EVENT_ASYNC, p, p->complete_dev, 0);
+  p->complete_cb(USB_EVENT_ASYNC, p, p->complete_dev, 0);
 }
 
 // Async packet support

--- a/bochs/iodev/usb/usb_common.h
+++ b/bochs/iodev/usb/usb_common.h
@@ -58,7 +58,6 @@
 #define USB_SPEED_FULL  1
 #define USB_SPEED_HIGH  2
 #define USB_SPEED_SUPER 3
-extern const char *usb_speed[4];
 
 #define USB_STATE_NOTATTACHED 0
 #define USB_STATE_ATTACHED    1

--- a/bochs/iodev/usb/usb_ehci.h
+++ b/bochs/iodev/usb/usb_ehci.h
@@ -332,7 +332,7 @@ public:
   virtual void after_restore_state(void);
   virtual void pci_write_handler(Bit8u address, Bit32u value, unsigned io_len);
 
-  void event_handler(int event, USBPacket *packet, int port);
+  int event_handler(int event, void *ptr, int port);
 
 private:
   bx_uhci_core_c *uhci[3];

--- a/bochs/iodev/usb/usb_floppy.h
+++ b/bochs/iodev/usb/usb_floppy.h
@@ -45,6 +45,8 @@
 #define UFI_READ_12                     0xA8
 #define UFI_WRITE_12                    0xAA
 
+#define UFI_DO_INQUIRY_HACK  1
+
 class device_image_t;
 
 class usb_floppy_device_c : public usb_device_c {
@@ -90,8 +92,10 @@ private:
     Bit8u cur_track;
     int sense;
     int asc;
+#if UFI_DO_INQUIRY_HACK
     int fail_count;
     bool did_inquiry_fail;
+#endif
     bool seek_pending;
     Bit8u *usb_buf;
     Bit8u *dev_buffer;

--- a/bochs/iodev/usb/usb_hub.h
+++ b/bochs/iodev/usb/usb_hub.h
@@ -51,7 +51,7 @@ public:
   virtual void after_restore_state();
   virtual void runtime_config();
   void restore_handler(bx_list_c *conf);
-  void event_handler(int event, USBPacket *packet, int port);
+  int event_handler(int event, void *ptr, int port);
 
 private:
   struct {

--- a/bochs/iodev/usb/usb_ohci.h
+++ b/bochs/iodev/usb/usb_ohci.h
@@ -259,7 +259,7 @@ public:
 
   virtual void pci_write_handler(Bit8u address, Bit32u value, unsigned io_len);
 
-  void event_handler(int event, USBPacket *packet, int port);
+  int event_handler(int event, void *ptr, int port);
 
 private:
 

--- a/bochs/iodev/usb/usb_uhci.cc
+++ b/bochs/iodev/usb/usb_uhci.cc
@@ -214,11 +214,13 @@ void bx_usb_uhci_c::after_restore_state()
   bx_uhci_core_c::after_restore_state();
 }
 
+int uhci_event_handler(int event, void *ptr, void *dev, int port);
+
 void bx_usb_uhci_c::init_device(Bit8u port, bx_list_c *portconf)
 {
   char pname[BX_PATHNAME_LEN];
 
-  if (DEV_usb_init_device(portconf, BX_UHCI_THIS_PTR, &BX_UHCI_THIS hub.usb_port[port].device)) {
+  if (DEV_usb_init_device(portconf, BX_UHCI_THIS_PTR, &BX_UHCI_THIS hub.usb_port[port].device, uhci_event_handler, port)) {
     if (set_connect_status(port, 1)) {
       portconf->get_by_name("options")->set_enabled(0);
       sprintf(pname, "usb_uhci.hub.port%d.device", port+1);

--- a/bochs/iodev/usb/usb_xhci.h
+++ b/bochs/iodev/usb/usb_xhci.h
@@ -344,6 +344,7 @@ enum { PLS_U0 = 0, PLS_U1, PLS_U2, PLS_U3_SUSPENDED, PLS_DISABLED, PLS_RXDETECT,
 #define TRB_GET_TARGET(x)    (((x) & (0x3FF << 22)) >> 22)
 #define TRB_GET_TX_LEN(x)     ((x) & 0x1FFFF)
 #define TRB_GET_TOGGLE(x)    (((x) & (1<<1)) >> 1)
+#define TRB_GET_STREAM(x)    (((x) & (0xFFFF << 16)) >> 16)
 
 #define TRB_DC(x)            (((x) & (1<<9)) >> 9)
 #define TRB_IS_IMMED_DATA(x) (((x) & (1<<6)) >> 6)
@@ -600,7 +601,7 @@ public:
 
   virtual void pci_write_handler(Bit8u address, Bit32u value, unsigned io_len);
 
-  void event_handler(int event, USBPacket *packet, int port);
+  int event_handler(int event, void *ptr, int port);
 
 private:
   bx_usb_xhci_t hub;

--- a/bochs/plugin.h
+++ b/bochs/plugin.h
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2002-2021  The Bochs Project
+//  Copyright (C) 2002-2023  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -252,7 +252,7 @@ extern "C" {
 #define DEV_mem_set_bios_rom_access(a,b) bx_devices.mem->set_bios_rom_access(a,b)
 
 ///////// USB device macro
-#define DEV_usb_init_device(a,b,c) bx_usbdev_ctl.init_device(a,b,(void**)c)
+#define DEV_usb_init_device(a,b,c,d,p) bx_usbdev_ctl.init_device(a,b,(void**)c,d,p)
 
 ///////// Sound module macros
 #define DEV_sound_get_waveout(a) (bx_soundmod_ctl.get_waveout(a))


### PR DESCRIPTION
  - fixed default speed setting
  - Now checks for a valid speed of a device depending on the Host Controller as well as the device's allowed speeds.
  - fixed SCSI:Request Sense
  - fixed SCSI:Mode Sense
  - fixed SCSI:Inquiry
  - added SCSI:Get Configuration
  - added SCSI:Request Sense: ASC and ASCQ
  - USBMSD now handles short packets instead of returning s.datalen (s.scsi_len is now returned)
  - added the start of UASP Task Management
  - UASP: Return Status includes Sense
  - fixed xHCI:SET_TR_DEQUEUE command
  - fixed resetting of the TD's toggle bit
  - I have had all devices work on Win95, Win98, WinXP, Win7, Win8, and Win10, except for a few quirks with 
           Super-speed CD-ROMs, EHCI's UASP support, and num_lock states with HIDs.
  - Added more documentation to user.dbk
  To be fixed:
  - USBMSD write in WinXP still gives error. I think it is a timing issue. Write works in later Windows versions.
