### PR TITLE
Fix for gdbstub with x86-64 that truncates instruction pointer while breakpoint check

### DIFF
--- a/bochs/bochs.h
+++ b/bochs/bochs.h
@@ -271,7 +271,7 @@ void print_statistics_tree(bx_param_c *node, int level = 0);
 // defines for GDB stub
 void bx_gdbstub_init(void);
 void bx_gdbstub_break(void);
-int bx_gdbstub_check(unsigned int eip);
+int bx_gdbstub_check(Bit64u eip);
 #define GDBSTUB_STOP_NO_REASON   (0xac0)
 
 #if BX_SUPPORT_SMP

--- a/bochs/cpu/cpu.cc
+++ b/bochs/cpu/cpu.cc
@@ -775,7 +775,12 @@ bool BX_CPU_C::dbg_instruction_epilog(void)
 
 #if BX_GDBSTUB
   if (bx_dbg.gdbstub_enabled) {
-    unsigned reason = bx_gdbstub_check(EIP);
+    unsigned reason =
+#if BX_SUPPORT_X86_64 == 0
+        bx_gdbstub_check(EIP);
+#else
+        bx_gdbstub_check(RIP);
+#endif
     if (reason != GDBSTUB_STOP_NO_REASON) return(1);
   }
 #endif

--- a/bochs/gdbstub.cc
+++ b/bochs/gdbstub.cc
@@ -257,7 +257,7 @@ void bx_gdbstub_break(void)
   bx_enter_gdbstub = 1;
 }
 
-int bx_gdbstub_check(unsigned int eip)
+int bx_gdbstub_check(Bit64u eip)
 {
   unsigned int i;
   unsigned char ch;
@@ -306,7 +306,7 @@ int bx_gdbstub_check(unsigned int eip)
   {
     if (eip == breakpoints[i])
     {
-      BX_INFO(("found breakpoint at %x", eip));
+      BX_INFO(("found breakpoint at " FMT_ADDRX64, eip));
       last_stop_reason = GDBSTUB_EXECUTION_BREAKPOINT;
       return GDBSTUB_EXECUTION_BREAKPOINT;
     }


### PR DESCRIPTION
While using breakpoints exceed 4GB limit, I noticed that they not work. This PR fixes it.