### PR TITLE
add symbol info to info idt on protected 32

### DIFF
--- a/bochs/bx_debug/dbg_main.cc
+++ b/bochs/bx_debug/dbg_main.cc
@@ -3141,6 +3141,11 @@ void bx_dbg_print_descriptor(Bit32u lo, Bit32u hi)
       default:
         // task, int, trap, or call gate.
         dbg_printf("target=0x%04x:0x%08x, DPL=%d", segment, offset, dpl);
+
+        const char *Sym = bx_dbg_disasm_symbolic_address(offset, 0);
+        if (Sym)
+          dbg_printf(" (%s)", Sym);
+
         break;
       }
     }


### PR DESCRIPTION
Before this PR **info idt** on **protected 32** (windows xp sp3 x86)

![before](https://github.com/bochs-emu/Bochs/assets/9882181/553c867c-c2f6-4ba6-9754-d66b659027bc)

As you can see the symbol exists but is not showed with **info idt**

So, with this PR:

![after](https://github.com/bochs-emu/Bochs/assets/9882181/b535d62c-ffe0-4657-99d2-98337ae8c43e)

