### PR TITLE
add port e9 hack support for all rings

### DIFF
--- a/bochs/.bochsrc
+++ b/bochs/.bochsrc
@@ -1310,10 +1310,12 @@ speaker: enabled=1, mode=sound, volume=15
 # very early when writing BIOS or OS code for example, without having to
 # bother with setting up a serial port or etc. Reading from port 0xE9 will
 # will return 0xe9 to let you know if the feature is available.
-# Leave this 0 unless you have a reason to use it.
+# Leave this 0 unless you have a reason to use it. By enabling the 
+# 'all_rings' option, you can utilize the port e9 hack from ring3.
 #
 # Example:
 #   port_e9_hack: enabled=1
+#   port_e9_hack: enabled=1, all_rings=1
 #=======================================================================
 #port_e9_hack: enabled=1
 

--- a/bochs/PARAM_TREE.txt
+++ b/bochs/PARAM_TREE.txt
@@ -285,6 +285,7 @@ sound
 
 misc
   port_e9_hack
+  port_e9_hack_all_rings
   gdbstub
     port
     text_base

--- a/bochs/cpu/io.cc
+++ b/bochs/cpu/io.cc
@@ -864,6 +864,10 @@ bool BX_CPP_AttrRegparmN(3) BX_CPU_C::allow_io(bxInstruction_c *i, Bit16u port, 
   /* If CPL <= IOPL, then all IO portesses are accessible.
    * Otherwise, must check the IO permission map on >286.
    * On the 286, there is no IO permissions map */
+  
+  static bool port_e9_hack_all_rings = SIM->get_param_bool(BXPN_PORT_E9_HACK_ALL_RINGS)->get();
+  if (0xe9 == port && port_e9_hack_all_rings)
+    return(1); // port e9 hack can be used by unprivileged code
 
   if (BX_CPU_THIS_PTR cr0.get_PE() && (BX_CPU_THIS_PTR get_VM() || (CPL > BX_CPU_THIS_PTR get_IOPL())))
   {

--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -5204,13 +5204,17 @@ Example:
 <screen>
   port_e9_hack: enabled=1
 </screen>
+<screen>
+  port_e9_hack: enabled=1, all_rings=1
+</screen>
 The 0xE9 port doesn't exists in normal ISA architecture. However, we
 define a convention here, to display on the console of the system running
 Bochs anything that is written to it. The idea is to provide debug output
 very early when writing BIOS or OS code for example, without having to
 bother with setting up a serial port or etc. Reading from port 0xE9 will
 will return 0xe9 to let you know if the feature is available. Leave
-this 0 unless you have a reason to use it.
+this 0 unless you have a reason to use it. By enabling the 'all_rings' 
+option, you can utilize the port e9 hack from ring3.
 </para>
 </section>
 

--- a/bochs/param_names.h
+++ b/bochs/param_names.h
@@ -175,6 +175,7 @@
 #define BXPN_SOUND_SB16                  "sound.sb16"
 #define BXPN_SOUND_ES1370                "sound.es1370"
 #define BXPN_PORT_E9_HACK                "misc.port_e9_hack"
+#define BXPN_PORT_E9_HACK_ALL_RINGS      "misc.port_e9_hack_all_rings"
 #define BXPN_GDBSTUB                     "misc.gdbstub"
 #define BXPN_LOG_FILENAME                "log.filename"
 #define BXPN_LOG_PREFIX                  "log.prefix"


### PR DESCRIPTION
By enabling the 'all_rings' option, you can utilize the port e9 hack from ring3

IMO very useful for:
- user-mode sandbox (ex Cuckoo)
- malware analysis
- API/SYSCALL logger with a simple hook from ring3
- automation + instrumentation from user mode code
- ...

So yes, from this PR a user-mode-sandbox can display on the console of the system running Bochs anything that is written to 0xE9 port

![porte9hackallrings](https://github.com/bochs-emu/Bochs/assets/9882181/ddbca3fa-729b-4a3e-95ad-078e44c7a17a)

**This PR is 100% backward compatibility**

btw, @stlintel I'm not certain if **bochs/config.cc** is the ideal location to define **bool port_e9_hack_all_rings** (unmapped io/dev is better?)
