### PR TITLE
add iodebug support for all rings

### DIFF
--- a/bochs/.bochsrc
+++ b/bochs/.bochsrc
@@ -1320,6 +1320,19 @@ speaker: enabled=1, mode=sound, volume=15
 #port_e9_hack: enabled=1
 
 #=======================================================================
+# IODEBUG:
+# I/O Interface to Bochs Debugger plugin allows the code running inside 
+# Bochs to monitor memory ranges, trace individual instructions, and 
+# observe register values during execution. By enabling the 'all_rings' 
+# option, you can utilize the iodebug ports from ring3. For more 
+# information, refer to "Advanced debugger usage" documentation.
+#
+# Example:
+#   iodebug: all_rings=1
+#=======================================================================
+#iodebug: all_rings=1
+
+#=======================================================================
 # fullscreen: ONLY IMPLEMENTED ON AMIGA
 #             Request that Bochs occupy the entire screen instead of a
 #             window.

--- a/bochs/PARAM_TREE.txt
+++ b/bochs/PARAM_TREE.txt
@@ -286,6 +286,7 @@ sound
 misc
   port_e9_hack
   port_e9_hack_all_rings
+  iodebug_all_rings
   gdbstub
     port
     text_base

--- a/bochs/cpu/io.cc
+++ b/bochs/cpu/io.cc
@@ -869,6 +869,12 @@ bool BX_CPP_AttrRegparmN(3) BX_CPU_C::allow_io(bxInstruction_c *i, Bit16u port, 
   if (0xe9 == port && port_e9_hack_all_rings)
     return(1); // port e9 hack can be used by unprivileged code
 
+#if BX_SUPPORT_IODEBUG
+  static bool iodebug_all_rings = SIM->get_param_bool(BXPN_IODEBUG_ALL_RINGS)->get();
+  if ((0x8A00 == port || 0x8A01 == port) && iodebug_all_rings)
+    return(1); // iodebug ports can be used by unprivileged code
+#endif /* if BX_SUPPORT_IODEBUG */
+
   if (BX_CPU_THIS_PTR cr0.get_PE() && (BX_CPU_THIS_PTR get_VM() || (CPL > BX_CPU_THIS_PTR get_IOPL())))
   {
     if (BX_CPU_THIS_PTR tr.cache.valid==0 ||

--- a/bochs/doc/docbook/user/user.dbk
+++ b/bochs/doc/docbook/user/user.dbk
@@ -5218,6 +5218,20 @@ option, you can utilize the port e9 hack from ring3.
 </para>
 </section>
 
+<section><title>IODEBUG</title>
+<para>
+Example:
+<screen>
+  iodebug: all_rings=1
+</screen>
+I/O Interface to Bochs Debugger plugin allows the code running inside 
+Bochs to monitor memory ranges, trace individual instructions, and 
+observe register values during execution. By enabling the 'all_rings' 
+option, you can utilize the iodebug ports from ring3. For more 
+information, refer to "Advanced debugger usage" documentation.
+</para>
+</section>
+
 </section> <!--end of bochsrc section-->
 
 <section id="keymap"><title>How to write your own keymap table</title>

--- a/bochs/param_names.h
+++ b/bochs/param_names.h
@@ -176,6 +176,7 @@
 #define BXPN_SOUND_ES1370                "sound.es1370"
 #define BXPN_PORT_E9_HACK                "misc.port_e9_hack"
 #define BXPN_PORT_E9_HACK_ALL_RINGS      "misc.port_e9_hack_all_rings"
+#define BXPN_IODEBUG_ALL_RINGS           "misc.iodebug_all_rings"
 #define BXPN_GDBSTUB                     "misc.gdbstub"
 #define BXPN_LOG_FILENAME                "log.filename"
 #define BXPN_LOG_PREFIX                  "log.prefix"


### PR DESCRIPTION
By enabling the iodebug's 'all_rings' option, you can utilize the port I/O Interface to Bochs Debugger from ring3. This PR allows the code running inside Bochs (ring3) to monitor memory ranges, trace individual instructions, and observe register values during execution.

https://bochs.sourceforge.io/doc/docbook/development/debugger-advanced.html

IMO very useful for:

- user-mode sandbox (ex Cuckoo)
- malware analysis
- API/SYSCALL hook/monitor from ring3
- automation + instrumentation from user mode code
...

A complement for PR #64

**This PR is 100% backward compatibility**

![IODEBUG ALL RINGS](https://github.com/bochs-emu/Bochs/assets/9882181/6308ad0f-c189-43f3-a92b-dccde3542ad6)

btw, @stlintel I'm not certain about:
- if misc is the ideal location for this.. should I create a new iodebug-option for this? 
- should I remove the #if in 'new bx_param_bool_c'?
- the new .bochsrc entry makes sense for you?