### PR TITLE
Fix zero length packet handling

### DIFF
--- a/bochs/iodev/usb/usb_common.h
+++ b/bochs/iodev/usb/usb_common.h
@@ -30,6 +30,8 @@
 #ifndef BX_IODEV_USB_COMMON_H
 #define BX_IODEV_USB_COMMON_H
 
+#include "iodev/iodev.h"
+
 // for the Packet Capture code to work, these four must remain as is
 #define USB_TRANS_TYPE_ISO      0
 #define USB_TRANS_TYPE_INT      1
@@ -237,6 +239,11 @@ public:
     }
   }
   int get_min_speed() { return d.minspeed; }
+  int get_default_speed(int speed) {
+    if ((speed >= d.minspeed) && (speed <= d.maxspeed))
+      return speed;
+    return d.minspeed; // will be no more than full-speed
+  }
   
   // return information for the specified ep of the current device
 #define USB_MAX_ENDPOINTS   5   // we currently don't use more than 5 endpoints (ep0, ep1, ep2, ep3, and ep4)
@@ -245,6 +252,9 @@ public:
   }
   int get_max_burst_size(const int ep) {
     return (ep < USB_MAX_ENDPOINTS) ? d.endpoint_info[ep].max_burst_size : 0;
+  }
+  int get_max_payload(const int ep) {
+    return (ep < USB_MAX_ENDPOINTS) ? (d.endpoint_info[ep].max_burst_size * d.endpoint_info[ep].max_packet_size) : 0;
   }
 
 #if HANDLE_TOGGLE_CONTROL
@@ -288,7 +298,7 @@ protected:
   struct {
     Bit8u type;
     bool connected;
-    int minspeed;
+    int minspeed;  // must be no more than FULL speed for *any* device
     int maxspeed;
     int speed;
     Bit8u addr;


### PR DESCRIPTION
This fixes zero length packet handling.
See the following example that requests 128 bytes:
```
SETUP(8)
IN(64)
IN(64)
STATUS(0)
```
The current code erroneously assumes that there are no more IN packets after the first two 64-byte packets.

However, what happens with the following:
```
SETUP(8)
IN(64)
IN(64)
IN(64)    <--- current code assumes this will be, and expects a STATUS packet
STATUS(0)
```
Currently, the third IN(64) above will result in a coding error because the code is expecting the STATUS packet, not another IN packet.

The "controller" must allow for more packets than expected, returning a short packet detect on the third IN(64) packet shown above, actually returning zero bytes, hence the Short Packet Detect.

This patch was tested on WinXP, Win7, and Win10.