### PR TITLE
Fix zero length packet handling

### DIFF
--- a/bochs/iodev/usb/usb_common.cc
+++ b/bochs/iodev/usb/usb_common.cc
@@ -49,22 +49,14 @@ bx_usbdev_ctl_c::bx_usbdev_ctl_c()
 
 void bx_usbdev_ctl_c::init(void)
 {
-  Bit8u i, j, count;
-
-  /*  If you wish to set DEBUG=report in the code, instead of
-   *  in the configuration, simply uncomment this line.  I use
-   *  it when I am working on this emulation.
-   */
-  //LOG_THIS setonoff(LOGLEV_DEBUG, ACT_REPORT);
-
-  count = PLUG_get_plugins_count(PLUGTYPE_USB);
+  Bit8u count = PLUG_get_plugins_count(PLUGTYPE_USB);
   usb_module_names = (const char**) malloc(count * sizeof(char*));
   usb_device_names = (const char**) malloc((count + 6) * sizeof(char*));
   usb_module_id = (Bit8u*) malloc((count + 5) * sizeof(Bit8u));
   usb_device_names[0] = "none";
   usb_module_id[0] = 0xff;
-  j = 1;
-  for (i = 0; i < count; i++) {
+  Bit8u j = 1;
+  for (Bit8u i = 0; i < count; i++) {
     usb_module_names[i] = PLUG_get_plugin_name(PLUGTYPE_USB, i);
     if (!strcmp(usb_module_names[i], "usb_hid")) {
       usb_device_names[j] = "mouse";
@@ -165,16 +157,14 @@ static const char *usb_speed[4] = {
 
 void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portconf)
 {
-  const char *raw_options;
-  int i, optc, speed = USB_SPEED_LOW;  // assume LOW speed device if parameter not given.
-  Bit8u devtype;
+  int speed = device->get_default_speed(USB_SPEED_FULL);  // try to default to FULL speed if parameter not given.
   char *opts[16];
 
   memset(opts, 0, sizeof(opts));
-  devtype = ((bx_param_enum_c *) portconf->get_by_name("device"))->get();
-  raw_options = ((bx_param_string_c *) portconf->get_by_name("options"))->getptr();
-  optc = bx_split_option_list("USB port options", raw_options, opts, 16);
-  for (i = 0; i < optc; i++) {
+  Bit8u devtype = ((bx_param_enum_c *) portconf->get_by_name("device"))->get();
+  const char *raw_options = ((bx_param_string_c *) portconf->get_by_name("options"))->getptr();
+  int optc = bx_split_option_list("USB port options", raw_options, opts, 16);
+  for (int i = 0; i < optc; i++) {
     if (!strncmp(opts[i], "speed:", 6)) {
       if (!strcmp(opts[i]+6, "low")) {
         speed = USB_SPEED_LOW;
@@ -195,7 +185,7 @@ void bx_usbdev_ctl_c::parse_port_options(usb_device_c *device, bx_list_c *portco
       BX_ERROR(("ignoring unknown USB device option: '%s'", opts[i]));
     }
   }
-  for (i = 0; i < optc; i++) {
+  for (int i = 0; i < optc; i++) {
     if (opts[i] != NULL) {
       free(opts[i]);
       opts[i] = NULL;
@@ -288,6 +278,11 @@ usb_device_c *usbdev_locator_c::create(const char *type, const char *devname)
 #undef LOG_THIS
 #define LOG_THIS
 
+// Generic USB packet handler
+#define SETUP_STATE_IDLE      0
+#define SETUP_STATE_DATA_IN   1
+#define SETUP_STATE_DATA_OUT  2
+
 // Base class for USB devices
 
 usb_device_c::usb_device_c(void)
@@ -301,7 +296,7 @@ usb_device_c::usb_device_c(void)
   for (int i=0; i<USB_MAX_ENDPOINTS; i++)
     d.endpoint_info[i].toggle = 0;
 #endif
-
+  d.setup_state = SETUP_STATE_IDLE;
 }
 
 usb_device_c::~usb_device_c()
@@ -320,15 +315,10 @@ usb_device_c *usb_device_c::find_device(Bit8u addr)
   }
 }
 
-// Generic USB packet handler
-
-#define SETUP_STATE_IDLE 0
-#define SETUP_STATE_DATA 1
-#define SETUP_STATE_ACK  2
-
 int usb_device_c::handle_packet(USBPacket *p)
 {
-  int l, ret = 0;
+  int mps = 8;
+  int ret = 0;
   int len = p->len;
   Bit8u *data = p->data;
 
@@ -336,9 +326,11 @@ int usb_device_c::handle_packet(USBPacket *p)
     case USB_MSG_ATTACH:
       d.state = USB_STATE_ATTACHED;
       break;
+      
     case USB_MSG_DETACH:
       d.state = USB_STATE_NOTATTACHED;
       break;
+      
     case USB_MSG_RESET:
       d.remote_wakeup = 0;
       d.addr = 0;
@@ -347,27 +339,33 @@ int usb_device_c::handle_packet(USBPacket *p)
       for (int i=0; i<USB_MAX_ENDPOINTS; i++)
         d.endpoint_info[i].toggle = 0;
 #endif
+      d.setup_state = SETUP_STATE_IDLE;
       handle_reset();
       break;
+      
     case USB_TOKEN_SETUP:
       if (d.state < USB_STATE_DEFAULT || p->devaddr != d.addr)
         return USB_RET_NODEV;
+      if (d.setup_state != SETUP_STATE_IDLE)
+        BX_ERROR(("SETUP packet found while expecting Status Packet?"));
       if (len != 8) {
         BX_ERROR(("Packet length must be 8."));
         goto fail;
       }
       // check the speed indicator from the TD
       if (d.speed != p->speed) {
-        BX_DEBUG(("SETUP: Packet Speed indicator doesn't match Device Speed indicator. %d != %d", p->speed, d.speed));
+        BX_ERROR(("SETUP: Packet Speed indicator doesn't match Device Speed indicator. %d != %d", p->speed, d.speed));
         goto fail;
       }
 #if HANDLE_TOGGLE_CONTROL
       // manage our toggle bit
-      if ((p->toggle > -1) && (p->toggle != 0)) {
-        BX_ERROR(("SETUP: Packet Toggle indicator doesn't match Device Toggle indicator. %d != 0", p->toggle));
-        goto fail;
+      if (p->toggle > -1) {
+        if (p->toggle != 0) {
+          BX_ERROR(("SETUP: Packet Toggle indicator doesn't match Device Toggle indicator. %d != 0", p->toggle));
+          goto fail;
+        }
+        set_toggle(USB_CONTROL_EP, 1); // after a SETUP packet, the toggle bit is set for the next packet
       }
-      set_toggle(USB_CONTROL_EP, 1); // after a SETUP packet, the toggle bit is set for the next packet
 #endif
       d.stall = 0;
       usb_dump_packet(data, 8, 0, p->devaddr, USB_DIR_OUT | p->devep, USB_TRANS_TYPE_CONTROL, true, false);
@@ -377,11 +375,25 @@ int usb_device_c::handle_packet(USBPacket *p)
 
       // check to see if the very first packet after an initial reset is an IN *and* 
       //  is for the first mps-bytes of the Device Descriptor. If not, give a warning.
-      if (!d.first8 && ((d.setup_len > get_mps(p->devep)) || (d.setup_buf[0] != (USB_DIR_IN | USB_TYPE_STANDARD | USB_RECIP_DEVICE)) || 
+      // Since we don't know the max packet size yet, we (the controller) assumes the following:
+      switch (d.speed) {
+        case USB_SPEED_LOW:
+          mps = 8;
+          break;
+        case USB_SPEED_FULL:
+        case USB_SPEED_HIGH:
+          mps = 64;
+          break;
+        case USB_SPEED_SUPER:
+          mps = 512;
+          break;
+      }
+      if (!d.first8 && ((d.setup_len != mps) || (d.setup_buf[0] != (USB_DIR_IN | USB_TYPE_STANDARD | USB_RECIP_DEVICE)) || 
                         (d.setup_buf[1] != USB_REQ_GET_DESCRIPTOR) || (d.setup_buf[3] != USB_DT_DEVICE))) {
-        BX_ERROR(("The first request after an initial reset must be the Device Descriptor request with a length less than or equal to max packet size."));
-        BX_ERROR(("The device expects a reset, MPS-bytes of the descriptor, another reset, set address request, and then the full 18 byte descriptor."));
-        BX_ERROR(("Some devices (more than you think) will not initialize correctly without this (non-USB compliant) sequence."));
+        BX_INFO(("The first request after an initial reset must be the Device Descriptor request with a length equal to the max packet size allowed for device."));
+        BX_INFO((" For low-speed devices, use an 8 byte length. For full- and high-speed, use a 64 byte length. For super-speed, use a 512 byte length."));
+        BX_INFO(("The device expects a reset, MPS-bytes of the descriptor, another reset, set address request, and then the full 18 byte descriptor."));
+        BX_INFO(("Some devices (more than you think) will not initialize correctly without this (non-USB compliant) sequence."));
       }
       d.first8 = 1;
       
@@ -389,176 +401,164 @@ int usb_device_c::handle_packet(USBPacket *p)
         ret = handle_control((d.setup_buf[0] << 8) | d.setup_buf[1],
                              (d.setup_buf[3] << 8) | d.setup_buf[2],
                              (d.setup_buf[5] << 8) | d.setup_buf[4],
-                             d.setup_len, d.data_buf);
+                              d.setup_len, d.data_buf);
         if (ret < 0)
           return ret;
         if (ret < d.setup_len)
           d.setup_len = ret;
-        d.setup_state = SETUP_STATE_DATA;
-      } else {
-        if (d.setup_len == 0)
-          d.setup_state = SETUP_STATE_ACK;
-        else
-          d.setup_state = SETUP_STATE_DATA;
-      }
+        d.setup_state = SETUP_STATE_DATA_IN;
+      } else
+        d.setup_state = SETUP_STATE_DATA_OUT;
       break;
+      
     case USB_TOKEN_IN:
       if (d.state < USB_STATE_DEFAULT || p->devaddr != d.addr)
         return USB_RET_NODEV;
       if (d.stall) goto fail;
       if (d.speed != p->speed) {
-        BX_DEBUG(("IN: Packet Speed indicator doesn't match Device Speed indicator. %d != %d", p->speed, d.speed));
+        BX_ERROR(("IN: Packet Speed indicator doesn't match Device Speed indicator. %d != %d", p->speed, d.speed));
         goto fail;
       }
       switch (p->devep) {
         case USB_CONTROL_EP:
           switch (d.setup_state) {
-            case SETUP_STATE_ACK:
+            // we are doing a data in packet
+            case SETUP_STATE_DATA_IN:
+              ret = d.setup_len - d.setup_index;
+              if (ret > len)
+                ret = len;
+
+              // check that the length is <= the max packet size of the device
+              if (ret > get_mps(USB_CONTROL_EP)) {
+                BX_ERROR(("EP%d transfer length (%d) is greater than Max Packet Size (%d).", p->devep, p->len, get_mps(USB_CONTROL_EP)));
+              }
+#if HANDLE_TOGGLE_CONTROL
+              // manage our toggle bit
+              if (p->toggle > -1) {
+                if (p->toggle != get_toggle(USB_CONTROL_EP)) {
+                  BX_ERROR(("CONTROL IN: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->toggle, get_toggle(USB_CONTROL_EP)));
+                  goto fail;
+                }
+                set_toggle(USB_CONTROL_EP, get_toggle(USB_CONTROL_EP) ^ 1); // toggle the bit
+              }
+#endif
+              if (ret > 0) {
+                memcpy(data, d.data_buf + d.setup_index, ret);
+                d.setup_index += ret;
+                usb_dump_packet(data, ret, 0, p->devaddr, USB_DIR_IN | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
+              }
+              break;
+              
+            // we were doing data out packets, now we are expecting an IN STATUS packet
+            case SETUP_STATE_DATA_OUT:
 #if HANDLE_TOGGLE_CONTROL
               // manage our toggle bit
               if ((p->toggle > -1) && (p->toggle != 1)) {
                 BX_ERROR(("STATUS: Packet Toggle indicator doesn't match Device Toggle indicator. %d != 1", p->toggle));
                 goto fail;
               }
-              //set_toggle(USB_CONTROL_EP, 0); // after a STATUS packet, the toggle bit is clear for the next packet
 #endif
-              if (!(d.setup_buf[0] & USB_DIR_IN)) {
-                d.setup_state = SETUP_STATE_IDLE;
-                ret = handle_control((d.setup_buf[0] << 8) | d.setup_buf[1],
-                                     (d.setup_buf[3] << 8) | d.setup_buf[2],
-                                     (d.setup_buf[5] << 8) | d.setup_buf[4],
-                                     d.setup_len, d.data_buf);
-                usb_dump_packet(d.data_buf, ret, 0, p->devaddr, USB_DIR_IN | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
-                if (ret > 0)
-                  ret = 0;
-              } else {
-                // return 0 byte
-              }
+              d.setup_state = SETUP_STATE_IDLE;
+              // found status packet from a Control OUT transfer, so process the transfer
+              ret = handle_control((d.setup_buf[0] << 8) | d.setup_buf[1],
+                                   (d.setup_buf[3] << 8) | d.setup_buf[2],
+                                   (d.setup_buf[5] << 8) | d.setup_buf[4],
+                                    d.setup_len, d.data_buf);
+              usb_dump_packet(d.data_buf, ret, 0, p->devaddr, USB_DIR_IN | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
+              // if the transfer was successful, return 0 for the STATUS packet,
+              //  else return the STALL, or other status.
+              if (ret > 0)
+                ret = 0;
               break;
-            case SETUP_STATE_DATA:
-              if (d.setup_buf[0] & USB_DIR_IN) {
-                l = d.setup_len - d.setup_index;
-                if (l > len)
-                  l = len;
-                  
-                // check that the length is <= the max packet size of the device
-                if (l > get_mps(USB_CONTROL_EP)) {
-                  BX_ERROR(("EP%d transfer length (%d) is greater than Max Packet Size (%d).", p->devep, p->len, get_mps(USB_CONTROL_EP)));
-                }
-#if HANDLE_TOGGLE_CONTROL
-                // manage our toggle bit
-                if ((p->toggle > -1) && (p->toggle != get_toggle(USB_CONTROL_EP))) {
-                  BX_ERROR(("CONTROL IN: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->toggle, get_toggle(USB_CONTROL_EP)));
-                  goto fail;
-                }
-                set_toggle(USB_CONTROL_EP, get_toggle(USB_CONTROL_EP) ^ 1); // toggle the bit
-#endif
-                memcpy(data, d.data_buf + d.setup_index, l);
-                d.setup_index += l;
-                // if the count of bytes transfered is an even packet size, we have to allow the host controller to (possibly) do a short packet
-                //  on the next zero byte transfer, so even if d.setup_index == d.setup_len we still have to allow another packet to be processed before
-                //  we go to SETUP_STATE_ACK. If there is not another IN packet (meaning the STATUS packet is next), the OUT code below handles
-                //  the STATUS stage for us.
-                if ((d.setup_index >= d.setup_len) && (l < get_mps(USB_CONTROL_EP)))
-                  d.setup_state = SETUP_STATE_ACK;
-                ret = l;
-                usb_dump_packet(data, ret, 0, p->devaddr, USB_DIR_IN | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
-              } else {
-                d.setup_state = SETUP_STATE_IDLE;
-                goto fail;
-              }
-              break;
+              
             default:
+              BX_ERROR(("Unknown Data state while finding Control In Packet."));
               goto fail;
           }
           break;
+          
+        // a non-control endpoint found
         default:
 #if HANDLE_TOGGLE_CONTROL
           // manage our toggle bit
-          if ((p->toggle > -1) && (p->toggle != get_toggle(p->devep))) {
-            BX_ERROR(("DATA IN EP%d: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->devep, p->toggle, get_toggle(p->devep)));
-            goto fail;
+          if (p->toggle > -1) {
+            if (p->toggle != get_toggle(p->devep)) {
+              BX_ERROR(("DATA IN EP%d: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->devep, p->toggle, get_toggle(p->devep)));
+              goto fail;
+            }
+            set_toggle(p->devep, get_toggle(p->devep) ^ 1); // toggle the bit
           }
-          set_toggle(p->devep, get_toggle(p->devep) ^ 1); // toggle the bit
 #endif
           ret = handle_data(p);
           break;
       }
       break;
+      
     case USB_TOKEN_OUT:
       if (d.state < USB_STATE_DEFAULT || p->devaddr != d.addr)
         return USB_RET_NODEV;
       if (d.stall) goto fail;
       if (d.speed != p->speed) {
-        BX_DEBUG(("OUT: Packet Speed indicator doesn't match Device Speed indicator. %d != %d", p->speed, d.speed));
+        BX_ERROR(("OUT: Packet Speed indicator doesn't match Device Speed indicator. %d != %d", p->speed, d.speed));
         goto fail;
       }
       switch (p->devep) {
         case USB_CONTROL_EP:
           switch(d.setup_state) {
-            case SETUP_STATE_ACK:
+            case SETUP_STATE_DATA_OUT:
+              ret = d.setup_len - d.setup_index;
+              if (ret > len)
+                ret = len;
+              
+              // check that the length is <= the max packet size of the device
+              if (ret > get_mps(USB_CONTROL_EP)) {
+                BX_ERROR(("EP%d transfer length (%d) is greater than Max Packet Size (%d).", p->devep, p->len, get_mps(USB_CONTROL_EP)));
+              }
+#if HANDLE_TOGGLE_CONTROL
+              // manage our toggle bit
+              if (p->toggle > -1) {
+                if (p->toggle != get_toggle(USB_CONTROL_EP)) {
+                  BX_ERROR(("CONTROL OUT: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->toggle, get_toggle(USB_CONTROL_EP)));
+                  goto fail;
+                }
+                set_toggle(USB_CONTROL_EP, get_toggle(USB_CONTROL_EP) ^ 1); // toggle the bit
+              }
+#endif
+              if (ret > 0) {
+                memcpy(d.data_buf + d.setup_index, data, ret);
+                d.setup_index += ret;
+                usb_dump_packet(data, ret, 0, p->devaddr, USB_DIR_OUT | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
+              }
+              break;
+
+            // we were doing data in packets, now we are expecting an OUT STATUS packet
+            case SETUP_STATE_DATA_IN:
 #if HANDLE_TOGGLE_CONTROL
               // manage our toggle bit
               if ((p->toggle > -1) && (p->toggle != 1)) {
                 BX_ERROR(("STATUS: Packet Toggle indicator doesn't match Device Toggle indicator. %d != 1", p->toggle));
                 goto fail;
               }
-              //set_toggle(USB_CONTROL_EP, 0); // after a STATUS packet, the toggle bit is clear for the next packet
 #endif
-              usb_dump_packet(p->data, p->len, 0, p->devaddr, USB_DIR_OUT | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
-              if (d.setup_buf[0] & USB_DIR_IN) {
-                d.setup_state = SETUP_STATE_IDLE;
-                // transfer OK
-              } else {
-                // ignore additional output
-              }
+              d.setup_state = SETUP_STATE_IDLE;
+              ret = 0;
               break;
-            case SETUP_STATE_DATA:
-              if (!(d.setup_buf[0] & USB_DIR_IN)) {
-                l = d.setup_len - d.setup_index;
-                if (l > len)
-                  l = len;
-                
-                // check that the length is <= the max packet size of the device
-                if (l > get_mps(USB_CONTROL_EP)) {
-                  BX_ERROR(("EP%d transfer length (%d) is greater than Max Packet Size (%d).", p->devep, p->len, get_mps(USB_CONTROL_EP)));
-                }
-#if HANDLE_TOGGLE_CONTROL
-                // manage our toggle bit
-                if ((p->toggle > -1) && (p->toggle != get_toggle(USB_CONTROL_EP))) {
-                  BX_ERROR(("CONTROL OUT: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->toggle, get_toggle(USB_CONTROL_EP)));
-                  goto fail;
-                }
-                set_toggle(USB_CONTROL_EP, get_toggle(USB_CONTROL_EP) ^ 1); // toggle the bit
-#endif
-                memcpy(d.data_buf + d.setup_index, data, l);
-                d.setup_index += l;
-                if (d.setup_index >= d.setup_len)
-                  d.setup_state = SETUP_STATE_ACK;
-                ret = l;
-                usb_dump_packet(data, ret, 0, p->devaddr, USB_DIR_OUT | p->devep, USB_TRANS_TYPE_CONTROL, false, true);
-              } else {
-                // it is okay for a host to send an OUT before it reads
-                //  all of the expected IN.  It is telling the controller
-                //  that it doesn't want any more from that particular call.
-                // or
-                //  we have (unexpectedly) encountered the STATUS packet.
-                ret = 0;
-                d.setup_state = SETUP_STATE_IDLE;
-              }
-              break;
+              
             default:
+              BX_ERROR(("Unknown Data state while finding Control Out Packet."));
               goto fail;
           }
           break;
         default:
 #if HANDLE_TOGGLE_CONTROL
           // manage our toggle bit
-          if ((p->toggle > -1) && (p->toggle != get_toggle(p->devep))) {
-            BX_ERROR(("DATA OUT EP%d: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->devep, p->toggle, get_toggle(p->devep)));
-            goto fail;
+          if (p->toggle > -1) {
+            if (p->toggle != get_toggle(p->devep)) {
+              BX_ERROR(("DATA OUT EP%d: Packet Toggle indicator doesn't match Device Toggle indicator. %d != %d", p->devep, p->toggle, get_toggle(p->devep)));
+              goto fail;
+            }
+            set_toggle(p->devep, get_toggle(p->devep) ^ 1);  // toggle the bit
           }
-          set_toggle(p->devep, get_toggle(p->devep) ^ 1);  // toggle the bit
 #endif
           ret = handle_data(p);
           break;
@@ -684,8 +684,8 @@ int usb_device_c::handle_control_common(int request, int value, int index, int l
         BX_ERROR(("USB_REQ_SET_CONFIGURATION: This type of request requires the wIndex and wLength fields to be zero."));
       }
       // check to make sure the requested value is within range
-      // (our one and only configuration)
-      if (value != d.config_descriptor[5]) {
+      // (our one and only configuration, *or* zero indicating to de-configure the device)
+      if ((value > 0) && (value != d.config_descriptor[5])) {
         BX_ERROR(("USB_REQ_SET_CONFIGURATION: Trying to set configuration value to non-existing configuration: %d", value));
       }
       d.config = value;
@@ -693,6 +693,7 @@ int usb_device_c::handle_control_common(int request, int value, int index, int l
       ret = 0;
       break;
     case DeviceOutRequest | USB_REQ_CLEAR_FEATURE:
+      BX_DEBUG(("USB_REQ_CLEAR_FEATURE: (%d)", value));
       // with DeviceOutRequest, The wIndex and wLength fields must be zero
       if ((index != 0) || (length != 0)) {
         BX_ERROR(("USB_REQ_CLEAR_FEATURE: This type of request requires the wIndex and wLength fields to be zero."));
@@ -742,6 +743,16 @@ int usb_device_c::handle_control_common(int request, int value, int index, int l
       if ((index == 0) && (value <= d.alt_iface_max)) {
         d.alt_iface = value;         // alternate interface
         handle_iface_change(value);  // let the device know we changed the interface number
+        ret = 0;
+      }
+      break;
+    case EndpointOutRequest | USB_REQ_CLEAR_FEATURE:
+      BX_DEBUG(("EndpointOutRequest | USB_REQ_CLEAR_FEATURE:"));
+      // Value == 0 == Endpoint Halt (the Guest wants to reset the endpoint)
+      if (value == 0) { /* clear ep halt */
+#if HANDLE_TOGGLE_CONTROL
+        set_toggle(index & 0x7F, 0);
+#endif
         ret = 0;
       }
       break;

--- a/bochs/iodev/usb/usb_common.h
+++ b/bochs/iodev/usb/usb_common.h
@@ -237,6 +237,11 @@ public:
     }
   }
   int get_min_speed() { return d.minspeed; }
+  int get_default_speed(int speed) {
+    if ((speed >= d.minspeed) && (speed <= d.maxspeed))
+      return speed;
+    return d.minspeed; // will be no more than full-speed
+  }
   
   // return information for the specified ep of the current device
 #define USB_MAX_ENDPOINTS   5   // we currently don't use more than 5 endpoints (ep0, ep1, ep2, ep3, and ep4)
@@ -245,6 +250,9 @@ public:
   }
   int get_max_burst_size(const int ep) {
     return (ep < USB_MAX_ENDPOINTS) ? d.endpoint_info[ep].max_burst_size : 0;
+  }
+  int get_max_payload(const int ep) {
+    return (ep < USB_MAX_ENDPOINTS) ? (d.endpoint_info[ep].max_burst_size * d.endpoint_info[ep].max_packet_size) : 0;
   }
 
 #if HANDLE_TOGGLE_CONTROL
@@ -288,7 +296,7 @@ protected:
   struct {
     Bit8u type;
     bool connected;
-    int minspeed;
+    int minspeed;  // must be no more than FULL speed for *any* device
     int maxspeed;
     int speed;
     Bit8u addr;


### PR DESCRIPTION
This fixes zero length packet handling.
See the following example that requests 128 bytes:

```
SETUP(8)
IN(64)
IN(64)
STATUS(0)
```

The current code erroneously assumes that there are no more IN packets after the first two 64-byte packets.

However, what happens with the following:

```
SETUP(8)
IN(64)
IN(64)
IN(64)    <--- current code assumes this will be, and expects a STATUS packet
STATUS(0)
```

Currently, the third IN(64) above will result in a coding error because the code is expecting the STATUS packet, not another IN packet.

The "controller" must allow for more packets than expected, returning a short packet detect on the third IN(64) packet shown above, actually returning zero bytes, hence the Short Packet Detect.

This patch was tested on WinXP, Win7, and Win10.