### PR TITLE
Additional controller checks

### DIFF
--- a/bochs/iodev/usb/usb_xhci.h
+++ b/bochs/iodev/usb/usb_xhci.h
@@ -445,6 +445,7 @@ typedef struct {
       bool   ca;             //  1 bit Command Abort               = 0              RW1S
       bool   cs;             //  1 bit Command Stop                = 0              RW1S
       bool   rcs;            //  1 bit Ring Cycle State            = 0              RW
+      Bit64u actual;         // Actual 64-bit value in this register (this register is read as zero, so we keep it here for internal reading)
     } HcCrcr;
     struct {
       Bit64u dcbaap;         // 64 bit hi order address            = 0x00000000     RW
@@ -603,8 +604,8 @@ public:
 
   int event_handler(int event, void *ptr, int port);
 
-private:
   bx_usb_xhci_t hub;
+private:
   Bit8u         devfunc;
   Bit8u         device_change;
   int           rt_conf_id;


### PR DESCRIPTION
This adds three additional checks to make sure the Guest is working correctly.
- checks that the guest allocated the Scratchpad Area. If left zero (NULL) the controller may access low memory.
- checks that the guest uses correct segment sizes in the interrupter ring(s)
- checks the burst size value given to be within normal range

This also adds an internal register value for the HcCrcr (Command Ring Control) register. Since this register reads zero by the Guest, we keep an internal value so that the emulation can read the value, internally.  This is for features soon to be released.

Minor other syntax/comment changes (misspelled word, etc)

Checked with WinXP, Win7, and Win10