### PR TITLE
Allow large VHD files

### DIFF
--- a/bochs/iodev/hdimage/vpc.cc
+++ b/bochs/iodev/hdimage/vpc.cc
@@ -203,10 +203,11 @@ int vpc_image_t::open(const char* _pathname, int flags)
   
   /* Allow a maximum disk size of 2040 GiB */
   if (sector_count > 0xff000000) {
+    BX_ERROR(("VHD Emulated Image too large. " FMT_LL "i > 4278190080", sector_count));
     bx_close_image(fd, pathname);
     return -EFBIG;
   }
-  
+
   if (disk_type == VHD_DYNAMIC) {
     if (bx_read_image(fd, be64_to_cpu(footer->data_offset), buf, HEADER_SIZE) != HEADER_SIZE) {
       bx_close_image(fd, pathname);

--- a/bochs/iodev/hdimage/vpc.h
+++ b/bochs/iodev/hdimage/vpc.h
@@ -69,7 +69,7 @@ typedef
 __declspec(align(1))
 #endif
 struct vhd_footer_t {
-    Bit8u   creator[8]; // "conectix"
+    char    creator[8]; // "conectix"
     Bit32u  features;
     Bit32u  version;
 
@@ -79,10 +79,10 @@ struct vhd_footer_t {
     // Seconds since Jan 1, 2000 0:00:00 (UTC)
     Bit32u  timestamp;
 
-    Bit8u   creator_app[4]; // "vpc "
+    char    creator_app[4]; // "vpc "
     Bit16u  major;
     Bit16u  minor;
-    Bit8u   creator_os[4]; // "Wi2k"
+    char    creator_os[4]; // "Wi2k"
 
     Bit64u  orig_size;
     Bit64u  size;


### PR DESCRIPTION
This PR allows larger VHD image files.  The size in question doesn't necessarily mean the size of the VHD file on disk. The size is the total size of the image emulated. This total size is in question.

Without this patch, the total size allowed is 65535 * 16 * 255, or roughly 32gig.
With this patch, the total size is calculated by who the creator of the image is, what the CHS values are, and possibly a total size of up to a limit of 2TB.

Since the original code was ported from QEMU, I ported an updated QEMU code snippet. 
https://gitlab.com/qemu-project/qemu/-/blob/master/block/vpc.c?ref_type=heads#L305

This PR now allows VHD image files with a total size emulated less than or equal to 2TB.