### PR TITLE
Add minimal support for MMC command 0xAC

### DIFF
--- a/bochs/iodev/usb/scsi_device.cc
+++ b/bochs/iodev/usb/scsi_device.cc
@@ -1289,7 +1289,7 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
       break;
     case 0x23:
       // USBMASS-UFI10.pdf  rev 1.0  Section 4.10
-      BX_INFO(("READ FORMAT CAPACITIES"));
+      BX_DEBUG(("READ FORMAT CAPACITIES"));
       
       // Cap List Header
       outbuf[0] = 0;
@@ -1308,6 +1308,18 @@ Bit32s scsi_device_t::scsi_send_command(Bit32u tag, Bit8u *buf, Bit8u cmd_len, i
       outbuf[10] = (Bit8u) ((block_size >>  8) & 0xFF);
       outbuf[11] = (Bit8u) ((block_size >>  0) & 0xFF);
       r->buf_len = 12;
+      break;
+    case 0xAC:
+      
+      // mmc6r02f.pdf, page 378 (330)
+      BX_DEBUG(("Get Performance:"));
+      BX_DEBUG((" %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11]));
+      //goto fail;
+      memset(outbuf, 0, 8);
+      outbuf[3] = 4;
+      r->buf_len = 8;
+      
       break;
     // The 0x9E command uses a service action code (ex: 0x9E/0x10)
     case 0x9E:


### PR DESCRIPTION
This changes a BX_INFO to a BX_DEBUG. It does not needed to be a BX_INFO.

Second, this adds (very) minimal support for SCSI command 0xAC.
When emulating a .iso image via USB CD-ROM on Win10, without this command, the emulation freezes when trying to access the CD-ROM. I don't know if it is Bochs or Win10. I think Win10 expects the command to work, or Bochs is not failing correctly.

This PR simply adds code to acknowledge the command and returns a zero length report. This SCSI (MMC) specification states that a zero length report is allowed.
The 8 byte header is returned, but the header indicates a zero byte return: No report segments returned.
This seems to keep Win10 from freezing at USB CD-ROM device access time.

The code also BX_DEBUG's the command sent to the "controller", for future use when adding the actual support of the command.