### PR TITLE
A small fix and addition for a TEAC CD-ROM driver

### DIFF
--- a/bochs/iodev/harddrv.h
+++ b/bochs/iodev/harddrv.h
@@ -43,15 +43,15 @@ class cdrom_base_c;
 
 typedef struct {
   struct {
-    bool busy;
-    bool drive_ready;
-    bool write_fault;
-    bool seek_complete;
-    bool drq;
-    bool corrected_data;
-    bool index_pulse;
+    bool busy;           // bit 7
+    bool drive_ready;    // bit 6
+    bool write_fault;    // bit 5
+    bool seek_complete;  // bit 4
+    bool drq;            // bit 3
+    bool corrected_data; // bit 2
+    bool index_pulse;    // bit 1
+    bool err;            // bit 0
     unsigned index_pulse_count;
-    bool err;
   } status;
   Bit8u    error_register;
   Bit8u    head_no;


### PR DESCRIPTION
This fixes the CD-ROM hardware by making sure the `drive_ready` flag is zero after an `ATAPI_DEVICE_RESET` command. As far as I know, no other Guest needed this fix except for the TEAC-CDI driver referred to below.

This also adds an assumption fix so that the TEAC_CDI driver will work.
The TEAC_CDI driver relies on the fact that the TEAC drive it is designed for, sets the `interrupt reason` register (`sector count` register) after the `ATAPI_IDENTIFY` command is issued. It uses this `i_o` bit of this register to determine the direction of transfer for the 0xA1 command, even though this is a read-only direction command.

Through other tests, I see no other Guests effected by this addition.

I also added a few minor syntax modifications, tab spacing, and comments. The DEBUG out string will display the ATAPI command as well as the 0xA0 command.