### PR TITLE
Add Modeless MessageBox capabilities

### DIFF
--- a/bochs/gui/gui.cc
+++ b/bochs/gui/gui.cc
@@ -819,17 +819,19 @@ void bx_gui_c::userbutton_handler(void)
 
 void bx_gui_c::save_restore_handler(void)
 {
-  int ret;
   char sr_path[BX_PATHNAME_LEN];
 
   if (BX_GUI_THIS dialog_caps & BX_GUI_DLG_SAVE_RESTORE) {
     BX_GUI_THIS set_display_mode(DISP_MODE_CONFIG);
     sr_path[0] = 0;
-    ret = SIM->ask_filename(sr_path, sizeof(sr_path),
+    int ret = SIM->ask_filename(sr_path, sizeof(sr_path),
                             "Save Bochs state to folder...", "none",
                             bx_param_string_c::SELECT_FOLDER_DLG);
     if ((ret >= 0) && (strcmp(sr_path, "none"))) {
+      void *hwnd = SIM->ml_message_box("Please wait.", "Waiting for the 'save state' to finish.\n"
+              "Depending on the size of your emulated disk images, this may be a little while.");
       if (SIM->save_state(sr_path)) {
+        SIM->ml_message_box_kill(hwnd);
         if (!SIM->ask_yes_no("WARNING",
               "The state of cpu, memory, devices and hard drive images is saved now.\n"
               "It is possible to continue, but when using the restore function in a\n"
@@ -838,6 +840,7 @@ void bx_gui_c::save_restore_handler(void)
           power_handler();
         }
       } else {
+        SIM->ml_message_box_kill(hwnd);
         SIM->message_box("ERROR", "Failed to save state");
       }
     }

--- a/bochs/gui/siminterface.cc
+++ b/bochs/gui/siminterface.cc
@@ -136,6 +136,10 @@ public:
   virtual int ask_yes_no(const char *title, const char *prompt, bool the_default);
   // simple message box
   virtual void message_box(const char *title, const char *message);
+  // simple modeless message box
+  virtual void *ml_message_box(const char *title, const char *message);
+  // kill modeless message box
+  virtual void ml_message_box_kill(void *ptr);
   // called at a regular interval, currently by the keyboard handler.
   virtual void periodic();
   virtual int create_disk_image(const char *filename, int sectors, bool overwrite);
@@ -659,6 +663,27 @@ void bx_real_sim_c::message_box(const char *title, const char *message)
   event.type = BX_SYNC_EVT_MSG_BOX;
   event.u.logmsg.prefix = title;
   event.u.logmsg.msg = message;
+  sim_to_ci_event(&event);
+}
+
+void *bx_real_sim_c::ml_message_box(const char *title, const char *message)
+{
+  BxEvent event;
+
+  event.type = BX_SYNC_EVT_ML_MSG_BOX;
+  event.param0 = NULL;
+  event.u.logmsg.prefix = title;
+  event.u.logmsg.msg = message;
+  sim_to_ci_event(&event);
+  return event.param0;
+}
+
+void bx_real_sim_c::ml_message_box_kill(void *ptr)
+{
+  BxEvent event;
+
+  event.type = BX_SYNC_EVT_ML_MSG_BOX_KILL;
+  event.param0 = ptr;
   sim_to_ci_event(&event);
 }
 

--- a/bochs/gui/siminterface.h
+++ b/bochs/gui/siminterface.h
@@ -217,6 +217,8 @@ typedef enum {
   BX_SYNC_EVT_LOG_DLG,            // simulator -> CI, wait for response.
   BX_SYNC_EVT_GET_DBG_COMMAND,    // simulator -> CI, wait for response.
   BX_SYNC_EVT_MSG_BOX,            // simulator -> CI, wait for response.
+  BX_SYNC_EVT_ML_MSG_BOX,         // simulator -> CI, do not wait for response.
+  BX_SYNC_EVT_ML_MSG_BOX_KILL,    // simulator -> CI, do not wait for response.
   __ALL_EVENTS_BELOW_ARE_ASYNC__,
   BX_ASYNC_EVT_KEY,               // vga window -> simulator
   BX_ASYNC_EVT_MOUSE,             // vga window -> simulator
@@ -407,6 +409,7 @@ typedef struct {
 typedef struct {
   BxEventType type; // what kind is this?
   Bit32s retcode;   // success or failure. only used for synchronous events.
+  void *param0;     // misc parameter
   union {
     BxKeyEvent key;
     BxMouseEvent mouse;
@@ -667,6 +670,10 @@ public:
   virtual int ask_yes_no(const char *title, const char *prompt, bool the_default) {return -1;}
   // simple message box
   virtual void message_box(const char *title, const char *message) {}
+  // modeless message box
+  virtual void *ml_message_box(const char *title, const char *message) {return NULL;}
+  // kill modeless message box
+  virtual void ml_message_box_kill(void *ptr) {}
   // called at a regular interval, currently by the bx_devices_c::timer()
   virtual void periodic() {}
   virtual int create_disk_image(const char *filename, int sectors, bool overwrite) {return -3;}


### PR DESCRIPTION
As an example, when saving the state of an emulation, especially one that has large image files and a large memory setting, there is a pause between the time you choose a directory to save to, and the MessageBox that states that the state was saved. During this time, there is no indication that Bochs is doing anything. As far as the user is concerned, Bochs froze.

So, this PR adds the capability to display a _Modeless_ message box. To do so, at any point you need a message box shown, allowing other things to continue to happen (SYNCHRONOUS), simply call the following line:
`void *hwnd = SIM->ml_message_box("Message Box Title", "Message Box Text");`
Then after the task has been performed, remove the message box:
`SIM->ml_message_box_kill(hwnd);`

The function is implemented in all configurations via virtual calls, however, the creation of the message box is currently only implemented in the Win32 configuration.  Other configurations will need this implemented, though I do not have those configurations to test with, except the text only config. I may get around to it :-).

This also currently only displays as the state is being saved. To display when the state is being restored should now be a simple task by adding the two lines shown above to the associated function.

The only drawback with this is that if the state is considerably small, the save will take just a second or less. If so, this window will show and then instantly be removed, possibly confusing the user. _What was that!!_
