### PR TITLE
fix ISO status change events

### DIFF
--- a/bochs/iodev/harddrv.h
+++ b/bochs/iodev/harddrv.h
@@ -253,7 +253,7 @@ private:
       Bit8u model_no[41];
       int statusbar_id;
       Bit8u device_num; // for ATAPI identify & inquiry
-      bool status_changed;
+      int  status_changed;
       int seek_timer_index;
     } drives[2];
     unsigned drive_select;


### PR DESCRIPTION
This allows you to change the CD-ROM via the Bochs Ribbon, as well as properly "ejecting" a CD from the guest.
Before the CD path would change, but the guest (tested with WinXP and DOS as guests) would not see the change.
This fix simulates an open tray and then a closed tray for all CD changes.