### PR TITLE
reset status bar items at reset

### DIFF
--- a/bochs/gui/gui.cc
+++ b/bochs/gui/gui.cc
@@ -420,6 +420,7 @@ void bx_gui_c::cdrom1_handler(void)
 void bx_gui_c::reset_handler(void)
 {
   BX_INFO(("system RESET callback"));
+  BX_GUI_THIS statusbar_setall(0);
   bx_pc_system.Reset(BX_RESET_HARDWARE);
 }
 
@@ -984,6 +985,12 @@ void bx_gui_c::statusbar_setitem(int element, bool active, bool w)
       statusitem[element].counter = 5;
     }
   }
+}
+
+void bx_gui_c::statusbar_setall(bool active)
+{
+  for (int i=0; i<BX_MAX_STATUSITEMS; i++)
+    statusbar_setitem(i, active);
 }
 
 void bx_gui_c::led_timer_handler(void *this_ptr)

--- a/bochs/gui/gui.h
+++ b/bochs/gui/gui.h
@@ -192,6 +192,7 @@ public:
   int register_statusitem(const char *text, bool auto_off=0);
   void unregister_statusitem(int id);
   void statusbar_setitem(int element, bool active, bool w=0);
+  void statusbar_setall(bool active);
   static void init_signal_handlers();
   static void toggle_mouse_enable(void);
   bool mouse_toggle_check(Bit32u key, bool pressed);


### PR DESCRIPTION
When the user presses the "Reset" button on the gui ribbon, we need to clear the active status of all statusbar items or they remain set after the reset occurs.
This is mentioned in issue #123 