### PR TITLE
Close cdrom image file on eject

### DIFF
--- a/bochs/CHANGES
+++ b/bochs/CHANGES
@@ -19,6 +19,7 @@ Brief summary :
   - USB: Added OHCI as an EHCI Companion option. Now allows UHCI or OHCI specified as a configuration parameter.
   - Disk images: Allows large VHD image files
   - Enhanced the Floppy Disk emulation
+  - Bug fix which now closes the cdrom image file when using win32 configuration
   - Documentation updates and fixes
 
 Detailed change log :

--- a/bochs/iodev/hdimage/cdrom_win32.cc
+++ b/bochs/iodev/hdimage/cdrom_win32.cc
@@ -147,6 +147,7 @@ cdrom_win32_c::~cdrom_win32_c(void)
   if (fd >= 0) {
     if (hFile != INVALID_HANDLE_VALUE)
       CloseHandle(hFile);
+    fd = -1;
   }
 }
 
@@ -209,6 +210,11 @@ void cdrom_win32_c::eject_cdrom()
       if (isWindowsXP) {
         DWORD lpBytesReturned;
         DeviceIoControl(hFile, IOCTL_STORAGE_EJECT_MEDIA, NULL, 0, NULL, 0, &lpBytesReturned, NULL);
+      }
+    } else {
+      if (hFile != INVALID_HANDLE_VALUE) {
+        CloseHandle(hFile);
+        hFile = INVALID_HANDLE_VALUE;
       }
     }
     fd = -1;


### PR DESCRIPTION
The WIN32 configuration for the cdrom was not closing the image file on eject. This left the handle open while Bochs was running, not allowing the image file to be modified.