### PR TITLE
Enable static library linking for MinGW builds

### DIFF
--- a/bochs/.conf.win32-cygwin
+++ b/bochs/.conf.win32-cygwin
@@ -18,6 +18,7 @@ export CXXFLAGS
 ./configure --enable-sb16 \
             --enable-ne2000 \
             --enable-all-optimizations \
+            --enable-static-link \
             --enable-cpu-level=6 \
             --enable-x86-64 \
             --enable-vmx=2 \

--- a/bochs/.conf.win64-cross-mingw32
+++ b/bochs/.conf.win64-cross-mingw32
@@ -21,6 +21,7 @@ export DLLTOOL
             --enable-sb16 \
             --enable-ne2000 \
             --enable-all-optimizations \
+            --enable-static-link \
             --enable-cpu-level=6 \
             --enable-x86-64 \
             --enable-vmx=2 \

--- a/bochs/configure
+++ b/bochs/configure
@@ -1028,6 +1028,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+enable_static_link
 enable_static
 enable_shared
 enable_fast_install
@@ -1751,6 +1752,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-static-link    link libraries statically [default=disabled]
   --enable-static[=PKGS]  build static libraries [default=no]
   --enable-shared[=PKGS]  build shared libraries [default=yes]
   --enable-fast-install[=PKGS]
@@ -3938,6 +3940,16 @@ printf "%s\n" "no" >&6; }
   cross_configure=0
 fi
 
+# Check whether --enable-static-link was given.
+if test ${enable_static_link+y}
+then :
+  enableval=$enable_static_link; enable_static_link="$enableval"
+else $as_nop
+  enable_static_link=no
+
+fi
+
+
 # this case statement defines the compile flags which are needed to
 # compile bochs on a platform.  Don't put things like optimization settings
 # into the configure.in file, since people will want to be able to change
@@ -3964,6 +3976,9 @@ case "$target" in
     ;;
   *-cygwin* | *-mingw32* | *-msys)
     NO_LT=1   # do not use libtool at all
+    if test "$enable_static_link" = yes; then
+      EXTRA_LINK_OPTS="${EXTRA_LINK_OPTS} -static"
+    fi
     if test "$with_term" = yes; then
       # ncurses won't compile with -DWIN32
       # also, I can't get it to link without this -DBROKEN_LINKER=1 hack.
@@ -6147,7 +6162,7 @@ ia64-*-hpux*)
   ;;
 *-*-irix6*)
   # Find out which ABI we are using.
-  echo '#line 6150 "configure"' > conftest.$ac_ext
+  echo '#line 6165 "configure"' > conftest.$ac_ext
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
@@ -7644,11 +7659,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7647: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7662: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7651: \$? = $ac_status" >&5
+   echo "$as_me:7666: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings
@@ -7878,11 +7893,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7881: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7896: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:7885: \$? = $ac_status" >&5
+   echo "$as_me:7900: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings
@@ -7946,11 +7961,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:7949: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:7964: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:7953: \$? = $ac_status" >&5
+   echo "$as_me:7968: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -9741,7 +9756,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 9744 "configure"
+#line 9759 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -9836,7 +9851,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 9839 "configure"
+#line 9854 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -11954,11 +11969,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:11957: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:11972: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:11961: \$? = $ac_status" >&5
+   echo "$as_me:11976: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings
@@ -12022,11 +12037,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:12025: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:12040: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:12029: \$? = $ac_status" >&5
+   echo "$as_me:12044: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -13045,7 +13060,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 13048 "configure"
+#line 13063 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -13140,7 +13155,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 13143 "configure"
+#line 13158 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -13960,11 +13975,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:13963: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:13978: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:13967: \$? = $ac_status" >&5
+   echo "$as_me:13982: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings
@@ -14028,11 +14043,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:14031: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:14046: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:14035: \$? = $ac_status" >&5
+   echo "$as_me:14050: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -15996,11 +16011,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:15999: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:16014: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:16003: \$? = $ac_status" >&5
+   echo "$as_me:16018: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings
@@ -16230,11 +16245,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:16233: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:16248: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>conftest.err)
    ac_status=$?
    cat conftest.err >&5
-   echo "$as_me:16237: \$? = $ac_status" >&5
+   echo "$as_me:16252: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s "$ac_outfile"; then
      # The compiler can only warn and ignore the option if not recognized
      # So say no if there are warnings
@@ -16298,11 +16313,11 @@ else $as_nop
    -e 's:.*FLAGS}? :&$lt_compiler_flag :; t' \
    -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
    -e 's:$: $lt_compiler_flag:'`
-   (eval echo "\"\$as_me:16301: $lt_compile\"" >&5)
+   (eval echo "\"\$as_me:16316: $lt_compile\"" >&5)
    (eval "$lt_compile" 2>out/conftest.err)
    ac_status=$?
    cat out/conftest.err >&5
-   echo "$as_me:16305: \$? = $ac_status" >&5
+   echo "$as_me:16320: \$? = $ac_status" >&5
    if (exit $ac_status) && test -s out/conftest2.$ac_objext
    then
      # The compiler can only warn and ignore the option if not recognized
@@ -18093,7 +18108,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 18096 "configure"
+#line 18111 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -18188,7 +18203,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 18191 "configure"
+#line 18206 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H
@@ -19958,7 +19973,7 @@ else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
   lt_status=$lt_dlunknown
   cat > conftest.$ac_ext <<EOF
-#line 19961 "configure"
+#line 19976 "configure"
 #include "confdefs.h"
 
 #if HAVE_DLFCN_H

--- a/bochs/configure.ac
+++ b/bochs/configure.ac
@@ -35,6 +35,13 @@ else
   cross_configure=0
 fi
 
+AC_ARG_ENABLE([static-link],
+  [AS_HELP_STRING([--enable-static-link],
+    [link libraries statically @<:@default=disabled@:>@])],
+  [enable_static_link="$enableval"],
+  [enable_static_link=no]
+)
+
 # this case statement defines the compile flags which are needed to
 # compile bochs on a platform.  Don't put things like optimization settings
 # into the configure.in file, since people will want to be able to change
@@ -59,6 +66,9 @@ case "$target" in
     ;;
   *-cygwin* | *-mingw32* | *-msys)
     NO_LT=1   # do not use libtool at all
+    if test "$enable_static_link" = yes; then
+      EXTRA_LINK_OPTS="${EXTRA_LINK_OPTS} -static"
+    fi
     if test "$with_term" = yes; then
       # ncurses won't compile with -DWIN32
       # also, I can't get it to link without this -DBROKEN_LINKER=1 hack.


### PR DESCRIPTION
This change allows to build Windows binaries without dependencies on toolchain-specific libraries (like `libc++.dll`).
It allows to perform version updates by copying of single `bochs.exe`, without the need for searching and distribution of linked DLLs.