### PR TITLE
Expand maximum resolution for Banshee and Voodoo 3 from 1600x1280 to 1920x1440

### DIFF
--- a/bochs/iodev/display/banshee.cc
+++ b/bochs/iodev/display/banshee.cc
@@ -2766,8 +2766,8 @@ bool bx_voodoo_vga_c::init_vga_extension(void)
     init_iohandlers(banshee_vga_read_handler, banshee_vga_write_handler);
     DEV_register_iowrite_handler(this, banshee_vga_write_handler, 0x0102, "banshee", 1);
     DEV_register_iowrite_handler(this, banshee_vga_write_handler, 0x46e8, "banshee", 1);
-    BX_VVGA_THIS s.max_xres = 1600;
-    BX_VVGA_THIS s.max_yres = 1280;
+    BX_VVGA_THIS s.max_xres = 1920;
+    BX_VVGA_THIS s.max_yres = 1440;
     v->banshee.disp_bpp = 8;
     BX_VVGA_THIS s.vclk[0] = 25175000;
     BX_VVGA_THIS s.vclk[1] = 28322000;

--- a/bochs/iodev/display/voodoo.cc
+++ b/bochs/iodev/display/voodoo.cc
@@ -319,8 +319,8 @@ void bx_voodoo_base_c::init(void)
   voodoo_init(s.model);
   if (s.model >= VOODOO_BANSHEE) {
     banshee_bitblt_init();
-    s.max_xres = 1600;
-    s.max_yres = 1280;
+    s.max_xres = 1920;
+    s.max_yres = 1440;
   } else {
     s.max_xres = 800;
     s.max_yres = 680;


### PR DESCRIPTION
Fixes #174.