### PR TITLE
Cancel topmost mode after leaving fullscreen mode

### DIFF
--- a/bochs/gui/win32.cc
+++ b/bochs/gui/win32.cc
@@ -825,6 +825,8 @@ void set_fullscreen_mode(BOOL enable)
     if (saveParent) {
       BX_DEBUG(("Restoring parent window"));
       SetParent(stInfo.mainWnd, saveParent);
+      SetWindowPos(stInfo.mainWnd, HWND_NOTOPMOST,
+        0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
       saveParent = NULL;
     }
     // put back the title bar, border, etc...


### PR DESCRIPTION
`HWND_TOPMOST` should be cancelled with `HWND_NOTOPMOST` when it is not needed anymore.