### PR TITLE
Init LDR whenever x2APIC mode is enabled

### DIFF
--- a/bochs/cpu/apic.cc
+++ b/bochs/cpu/apic.cc
@@ -288,15 +288,16 @@ void bx_local_apic_c::enable_xapic_extensions(void)
 
 void bx_local_apic_c::set_base(bx_phy_address newbase)
 {
-#if BX_CPU_LEVEL >= 6
-  if (mode == BX_APIC_X2APIC_MODE)
-    ldr = ((apic_id & 0xfffffff0) << 16) | (1 << (apic_id & 0xf));
-#endif
   mode = (newbase >> 10) & 3;
   newbase &= ~((bx_phy_address) 0xfff);
   base_addr = newbase;
   BX_INFO(("allocate APIC id=%d (MMIO %s) to 0x" FMT_PHY_ADDRX,
     apic_id, (mode == BX_APIC_XAPIC_MODE) ? "enabled" : "disabled", newbase));
+
+#if BX_CPU_LEVEL >= 6
+  if (mode == BX_APIC_X2APIC_MODE)
+    ldr = ((apic_id & 0xfffffff0) << 16) | (1 << (apic_id & 0xf));
+#endif
 
   if (mode == BX_APIC_GLOBALLY_DISABLED) {
     // if local apic becomes globally disabled reset some fields back to defaults


### PR DESCRIPTION
According to Intel SDM vol3 11.12.10.2 (Deriving Logical x2APIC ID from the Local x2APIC ID), "The LDR initialization occurs whenever the x2APIC mode is enabled".