### PR TITLE
Stub the bxInstrument_c class too

### DIFF
--- a/bochs/instrument/stubs/instrument.cc
+++ b/bochs/instrument/stubs/instrument.cc
@@ -24,6 +24,8 @@
 
 #if BX_INSTRUMENTATION
 
+class bxInstruction_c;
+
 void bx_instr_init_env(void) {}
 void bx_instr_exit_env(void) {}
 


### PR DESCRIPTION
The instrument stub needs this, otherwise

./configure --enable-instrumentation && make

fails because bxInstrument_c isn't declared.