### PR TITLE
Allow BX_SHARE_PATH to be used in BIOS paths

### DIFF
--- a/bochs/config.cc
+++ b/bochs/config.cc
@@ -2097,7 +2097,7 @@ const char *get_builtin_variable(const char *varname)
       if (code == ERROR_SUCCESS) {
         data[0] = 0;
         size = MAX_PATH;
-        if (RegQueryValueEx(hkey, "", NULL, (LPDWORD)&type, (LPBYTE)data,
+        if (RegQueryValueEx(hkey, "BX_SHARE_PATH", NULL, (LPDWORD)&type, (LPBYTE)data,
                             (LPDWORD)&size) == ERROR_SUCCESS) {
           RegCloseKey(hkey);
           return data;


### PR DESCRIPTION
This allows the Window's Environment variable BX_SHARE_PATH to be used in paths within your bochsrc file.

Environment variable:
`BX_SHARE_PATH`
Value:
`D:\some\path`

Before:
`romimage: file=D:/some/path/bios/BIOS-bochs-latest`
After:
`romimage: file=$BXSHARE/bios/BIOS-bochs-latest`

Please note that I don't know why the parameter was initially empty. Was this to catch a base/default parameter? 
If the `lpValueName` parameter is NULL or an empty string, Windows will return a (possibly non-existent) default value.
With this PR, we specify the actual parameter of `BX_SHARE_PATH`.
