### PR TITLE
check the nps bit before operating on the psm bit

### DIFF
--- a/bochs/iodev/usb/ohci_core.h
+++ b/bochs/iodev/usb/ohci_core.h
@@ -2,8 +2,8 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2009-2023  Benjamin D Lunt (fys [at] fysnet [dot] net)
-//                2009-2023  The Bochs Project
+//  Copyright (C) 2009-2024  Benjamin D Lunt (fys [at] fysnet [dot] net)
+//                2009-2024  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -247,7 +247,9 @@ public:
 
   int event_handler(int event, void *ptr, int port);
 
+#if !BX_USE_WIN32USBDEBUG
 protected:
+#endif
   bx_ohci_core_t hub;
 
   USBAsync *packets;


### PR DESCRIPTION
The PSM bit is only valid if NPS = 0 and a few other minor additions and syntax fixes