### PR TITLE
Fix checking Android platform with __ANDROID__ macro

### DIFF
--- a/bochs/gui/sdl.cc
+++ b/bochs/gui/sdl.cc
@@ -335,14 +335,14 @@ void switch_to_fullscreen(void)
 {
   SDL_FreeSurface(sdl_screen);
   sdl_screen = NULL;
-#ifdef ANDROID
+#ifdef __ANDROID__
   sdl_fullscreen = SDL_SetVideoMode(res_x,res_y,32, SDL_SWSURFACE|SDL_FULLSCREEN);
 #else
   sdl_fullscreen = SDL_SetVideoMode(res_x,res_y,32, SDL_HWSURFACE|SDL_FULLSCREEN);
 #endif
   DEV_vga_refresh(1);
   SDL_ShowCursor(0);
-#ifndef ANDROID
+#ifndef __ANDROID__
   if (sdl_grab == 0) {
     SDL_WM_GrabInput(SDL_GRAB_ON);
     sdl_grab = 1;
@@ -418,7 +418,7 @@ bx_sdl_gui_c::bx_sdl_gui_c()
   atexit(SDL_Quit);
 #endif
 
-#ifdef ANDROID
+#ifdef __ANDROID__
   modes = SDL_ListModes(NULL, SDL_FULLSCREEN|SDL_SWSURFACE);
 #else
   modes = SDL_ListModes(NULL, SDL_FULLSCREEN|SDL_HWSURFACE);
@@ -1006,7 +1006,7 @@ void bx_sdl_gui_c::dimension_update(unsigned x, unsigned y,
   guest_yres = y;
 
   if ((x == res_x) && (y == res_y)) return;
-#ifndef ANDROID
+#ifndef __ANDROID__
   // This is not needed on Android
   if (((int)x > sdl_maxres.w) || ((int)y > sdl_maxres.h)) {
     BX_PANIC(("dimension_update(): resolution of out of display bounds"));
@@ -1040,7 +1040,7 @@ void bx_sdl_gui_c::dimension_update(unsigned x, unsigned y,
         BX_HEADERBAR_BG_GREEN,
         BX_HEADERBAR_BG_BLUE);
   } else {
-#ifdef ANDROID
+#ifdef __ANDROID__
     sdl_fullscreen = SDL_SetVideoMode(x, y, 32, SDL_SWSURFACE|SDL_FULLSCREEN);
 #else
     sdl_fullscreen = SDL_SetVideoMode(x, y, 32, SDL_HWSURFACE|SDL_FULLSCREEN);

--- a/bochs/gui/sdl2.cc
+++ b/bochs/gui/sdl2.cc
@@ -987,7 +987,7 @@ void bx_sdl2_gui_c::dimension_update(unsigned x, unsigned y,
 
   if ((x == res_x) && (y == res_y)) return;
 
-#ifndef ANDROID
+#ifndef __ANDROID__
   // This is not needed on Android
   if (((int)x > sdl_maxres.w) || ((int)y > sdl_maxres.h)) {
     BX_PANIC(("dimension_update(): resolution of out of display bounds"));

--- a/bochs/iodev/gameport.cc
+++ b/bochs/iodev/gameport.cc
@@ -32,7 +32,7 @@
 
 #ifdef __linux__
 
-#ifndef ANDROID
+#ifndef __ANDROID__
 #include <linux/joystick.h>
 #endif
 #include <sys/types.h>
@@ -136,7 +136,7 @@ void bx_gameport_c::register_state(void)
 
 void bx_gameport_c::poll_joydev(void)
 {
-#ifndef ANDROID
+#ifndef __ANDROID__
 #ifdef __linux__
   struct js_event e;
   fd_set joyfds;
@@ -181,7 +181,7 @@ void bx_gameport_c::poll_joydev(void)
     BX_GAMEPORT_THIS delay_y = 25 + (joypos.wYpos / 60);
   }
 #endif
-#endif //ANDROID
+#endif //__ANDROID__
 }
 
 // static IO port read callback handler

--- a/bochs/iodev/harddrv.cc
+++ b/bochs/iodev/harddrv.cc
@@ -3373,7 +3373,7 @@ bool bx_hard_drive_c::bmdma_present(void)
 {
   #if BX_SUPPORT_PCI
     if (BX_HD_THIS pci_enabled) {
-      #ifndef ANDROID
+      #ifndef __ANDROID__
       // DMA emulation works very bad under Android
       return DEV_ide_bmdma_present();
       #endif

--- a/bochs/iodev/network/slirp/misc.cc
+++ b/bochs/iodev/network/slirp/misc.cc
@@ -177,7 +177,7 @@ fork_exec(struct socket *so, const char *ex, int do_pty)
 		dup2(s, 0);
 		dup2(s, 1);
 		dup2(s, 2);
-#ifdef ANDROID
+#ifdef __ANDROID__
 		{
 			/* No getdtablesize() on Android, we will use /proc/XXX/fd/ Linux virtual FS instead */
 			char proc_fd_path[256];

--- a/bochs/iodev/sound/es1370.cc
+++ b/bochs/iodev/sound/es1370.cc
@@ -379,7 +379,7 @@ void bx_es1370_c::reset(unsigned type)
     BX_ES1370_THIS s.chan[i].leftover = 0;
   }
 
-  #ifndef ANDROID
+  #ifndef __ANDROID__
   // Gameport is unsupported on Android
   DEV_gameport_set_enabled(0);
   #endif
@@ -615,7 +615,7 @@ void bx_es1370_c::write(Bit32u address, Bit32u value, unsigned io_len)
       mask = (0xffffffff >> ((4 - io_len) << 3)) << shift;
       value = (BX_ES1370_THIS s.ctl & ~mask) | ((value << shift) & mask);
       if ((value ^ BX_ES1370_THIS s.ctl) & 0x04) {
-        #ifndef ANDROID
+        #ifndef __ANDROID__
         // Gameport is unsupported on Android
         DEV_gameport_set_enabled((value & 0x04) != 0);
         #endif

--- a/bochs/iodev/sound/soundlow.h
+++ b/bochs/iodev/sound/soundlow.h
@@ -86,7 +86,7 @@ void convert_float_to_s16le(float *src, unsigned srcsize, Bit8u *dst);
 BOCHSAPI_MSVCONLY Bit32u pcm_callback(void *dev, Bit16u rate, Bit8u *buffer, Bit32u len);
 
 extern BX_MUTEX(resampler_mutex);
-#ifndef ANDROID
+#ifndef __ANDROID__
 extern BX_MUTEX(mixer_mutex);
 #endif
 

--- a/bochs/misc/bswap.h
+++ b/bochs/misc/bswap.h
@@ -71,7 +71,7 @@ BX_CPP_INLINE void WriteHostDWordToLittleEndian(Bit32u *hostPtr, Bit32u nativeVa
 
 BX_CPP_INLINE void WriteHostQWordToLittleEndian(Bit64u *hostPtr, Bit64u nativeVar64)
 {
-#ifdef ANDROID
+#ifdef __ANDROID__
 // Resolve problems with unaligned access
   ((Bit8u *)(hostPtr))[0] = (Bit8u) (nativeVar64);
   ((Bit8u *)(hostPtr))[1] = (Bit8u) ((nativeVar64)>>8);
@@ -98,7 +98,7 @@ BX_CPP_INLINE Bit32u ReadHostDWordFromLittleEndian(Bit32u *hostPtr)
 
 BX_CPP_INLINE Bit64u ReadHostQWordFromLittleEndian(Bit64u *hostPtr)
 {
-#ifdef ANDROID
+#ifdef __ANDROID__
 // Resolve problems with unaligned access
   Bit64u nativeVar64 = ((Bit64u) ((Bit8u *)(hostPtr))[0]) |
                        (((Bit64u) ((Bit8u *)(hostPtr))[1])<<8) |


### PR DESCRIPTION

    This change fixes compiler errors in Android as following.
    
    ../../../iodev/sound/soundoss.cc:43:10: fatal error: 'sys/soundcard.h' file not found
       43 | #include <sys/soundcard.h>
          |          ^~~~~~~~~~~~~~~~~
    ../../../iodev/network/slirp/misc.cc:195:12: error: use of undeclared identifier 'getdtablesize'; did you mean 'getpagesize'?
      195 |                 for (s = getdtablesize() - 1; s >= 3; s--)
          |                          ^~~~~~~~~~~~~
          |                          getpagesize
    /data/data/com.termux/files/usr/include/unistd.h:356:5: note: 'getpagesize' declared here
      356 | int getpagesize(void) __INTRODUCED_IN(21);
          |     ^
    
    The official documentation also suggests to use __ANDROID__ macro which
    is defined by the compiler irrespective of included headers and build system.
    https://android.googlesource.com/platform/bionic/+/HEAD/docs/defines.md
