### PR TITLE
Update cpuid.cc - label and abbreviation corrections SMX, MPX

### DIFF
--- a/bochs/cpu/cpuid.cc
+++ b/bochs/cpu/cpuid.cc
@@ -392,7 +392,7 @@ Bit32u bx_cpuid_t::get_std_cpuid_leaf_1_ecx(Bit32u extra) const
     ecx |= BX_CPUID_STD1_ECX_VMX;
 #endif
 
-  // [6:6]   SMX: Secure Virtual Machine Technology - not supported
+  // [6:6]   SMX: Safer Mode Extensions for Trusted Execution Technology (TXT) - not supported
   // [7:7]   EST: Enhanced Intel SpeedStep Technology - not supported, could be enabled through extra
   // [8:8]   TM2: Thermal Monitor 2 - not supported, could be enabled through extra
 
@@ -834,7 +834,7 @@ Bit32u bx_cpuid_t::get_std_cpuid_leaf_7_ebx(Bit32u extra) const
   if (is_cpu_extension_supported(BX_ISA_FCS_FDS_DEPRECATION))
     ebx |= BX_CPUID_STD7_SUBLEAF0_EBX_DEPRECATE_FCS_FDS;
 
-  // [14:14]  Intel Memory Protection Extensions - not supported
+  // [14:14]  Intel Memory Protection Extensions (MPX) - not supported
   // [15:15]  Supports Platform Quality of Service Enforcement (PQE) capability - not supported
 
   // [16:16]  AVX512F instructions support


### PR DESCRIPTION
Memory Protection Extensions - add MPX abbreviation

SMX: Secure Virtual Machine Technology - bit6 is for SMX, but [it's meaning](https://en.wikipedia.org/wiki/CPUID) is Safer Mode Extensions (part of TXT). Not Secure Virtual Machine Technology (which is already listed elsewhere as SVM).