### PR TITLE
Fix big-endian support in bx_banshee_c::mem_read

### DIFF
--- a/bochs/iodev/display/banshee.cc
+++ b/bochs/iodev/display/banshee.cc
@@ -947,7 +947,7 @@ void bx_banshee_c::mem_read(bx_phy_address addr, unsigned len, void *data)
       *((Bit8u*)data + 2) = (Bit8u)(value >> 16);
 #else
       for (unsigned i = 0; i < 3; i++) {
-        *((Bit8u*)data + i) = (Bit8u)(value >> ((2 - i) << 8));
+        *((Bit8u*)data + i) = (Bit8u)(value >> ((2 - i) << 3));
       }
 #endif
       break;


### PR DESCRIPTION
Byte reversing code in commit 52c2fbee5e76f45c1725971634ebab2c984a9556 uses `8` bit shift, while `3` bit shift should be used instead.

Tested with Debian 7 _([hdd image](https://people.debian.org/~aurel32/qemu/powerpc/))_ inside of QEMU PowerPC emulation:

![qemu_bochs_win311_voodoo](https://github.com/user-attachments/assets/097f70b7-95aa-4e4f-857b-53e0c6fdafdf)
