### PR TITLE
UHCI: do not deactivate TDs on NAKs

### DIFF
--- a/bochs/iodev/usb/uhci_core.h
+++ b/bochs/iodev/usb/uhci_core.h
@@ -215,7 +215,7 @@ protected:
   static void uhci_timer_handler(void *);
   void uhci_timer(void);
   bool DoTransfer(Bit32u address, struct TD *);
-  void set_status(struct TD *td, bool stalled, bool data_buffer_error, bool babble,
+  void set_status(struct TD *td, bool active, bool stalled, bool data_buffer_error, bool babble,
     bool nak, bool crc_time_out, bool bitstuff_error, Bit16u act_len);
 
   static Bit32u read_handler(void *this_ptr, Bit32u address, unsigned io_len);


### PR DESCRIPTION
NAKs from USB devices do not deactivate TDs according to the official UHCI spec (page 22).

Reference: http://ftp.netbsd.org/pub/NetBSD/misc/blymn/uhci11d.pdf