### PR TITLE
Get DESTDIR from the environment and add distclean target.

### DIFF
--- a/bochs/Makefile.in
+++ b/bochs/Makefile.in
@@ -35,8 +35,6 @@ sharedir        = $(datarootdir)/bochs
 top_builddir    = .
 top_srcdir      = $(srcdir)
 
-DESTDIR =
-
 VERSION=@VERSION@
 REL_STRING=@REL_STRING@
 MAN_PAGE_1_LIST=bochs bximage bochs-dlx
@@ -605,6 +603,8 @@ all-clean: clean @CLEAN_DOCBOOK_VAR@ @CLEAN_PCIDEV_VAR@
 	cd misc @COMMAND_SEPARATOR@
 	$(MAKE) clean
 	@CD_UP_ONE@
+
+distclean: dist-clean
 
 dist-clean: local-dist-clean
 	cd iodev @COMMAND_SEPARATOR@

--- a/bochs/doc/docbook/Makefile.in
+++ b/bochs/doc/docbook/Makefile.in
@@ -26,8 +26,6 @@ SGML_VALIDATE = nsgmls -s
 DOCBOOK2HTML = $(JADE) $(JADE_ARGS)
 endif
 
-DESTDIR=
-
 # name of the major documentation sections
 SECTIONS=user documentation development
 SECTION_HTML=$(SECTIONS:%=%/index.html)


### PR DESCRIPTION
autoconf-based packages conventionally respect the DESTDIR environment variable rather needing to explicitly override it.

Likewise the distclean target is conventionally named distclean rather than dist-clean. This change adds a top-level alias to be compatible.

These changes are needed to build bochs on my infrastructure without having to special case bochs or locally patch it.