### PR TITLE
Fix printf format issues.

### DIFF
--- a/bochs/iodev/hdimage/vbox.cc
+++ b/bochs/iodev/hdimage/vbox.cc
@@ -138,7 +138,7 @@ int vbox_image_t::open(const char* _pathname, int flags)
   // (10gig = 10240 1-meg blocks with each entry using 4 bytes) = 40k
   mtlb = new Bit32s[(unsigned) header.blocks_in_hdd];
   if (mtlb == 0) {
-    BX_PANIC(("unable to allocate %lu bytes for vbox image's map table", header.blocks_in_hdd * sizeof(Bit32u)));
+    BX_PANIC(("unable to allocate %lu bytes for vbox image's map table", (unsigned long) (header.blocks_in_hdd * sizeof(Bit32u))));
   }
 
   // read in the map table

--- a/bochs/iodev/hpet.cc
+++ b/bochs/iodev/hpet.cc
@@ -391,7 +391,7 @@ void bx_hpet_c::hpet_set_timer(HPETTimer *t)
   }
   if (diff < HPET_MIN_ALLOWED_PERIOD) diff = HPET_MIN_ALLOWED_PERIOD;
   if (diff > HPET_MAX_ALLOWED_PERIOD) diff = HPET_MAX_ALLOWED_PERIOD;
-  BX_DEBUG(("Timer %d to fire in 0x%lX ticks", t->tn, diff));
+  BX_DEBUG(("Timer %d to fire in 0x" FMT_LL "X ticks", t->tn, diff));
   bx_pc_system.activate_timer_nsec(t->timer_id, ticks_to_ns(diff), 0);
 }
 


### PR DESCRIPTION
These issues appear when -Werror=format on 32-bit platforms depending on the exact definitions of uint64_t and size_t.

It doesn't appear that bochs uses %zu for size_t -- since you support Windows platforms, unclear if that would work for you. If so, that's definitely correct rather than the unsigned long cast.