### PR TITLE
widen 'bytes' column

### DIFF
--- a/bochs/gui/enh_dbg.cc
+++ b/bochs/gui/enh_dbg.cc
@@ -1411,7 +1411,7 @@ void FillGDT()
     unsigned int k = (GDT_Len + 1) / 8;
     Bit8u gdtbuf[8];
     char *cols[18];
-    char gdttxt[90];
+    char gdttxt[100];
     doDumpRefresh = FALSE;
 
     Bit64u laddr = rV[GDTRnum];
@@ -1420,8 +1420,8 @@ void FillGDT()
     *gdttxt = 0;
     cols[0]= gdttxt + 1;
     cols[1]= gdttxt + 30;
-    cols[2]= gdttxt + 40;
-    cols[3]= gdttxt + 80;
+    cols[2]= gdttxt + 50;
+    cols[3]= gdttxt + 90;
     cols[4]= gdttxt;    // columns #5 to 17 are blank
     cols[5]= gdttxt;
     cols[6]= gdttxt;

--- a/bochs/gui/win32_enh_dbg_osdep.cc
+++ b/bochs/gui/win32_enh_dbg_osdep.cc
@@ -8,7 +8,7 @@
 //
 //  Modified by Bruce Ewing
 //
-//  Copyright (C) 2008-2021  The Bochs Project
+//  Copyright (C) 2008-2024  The Bochs Project
 
 #include "bochs.h"
 #include "bx_debug/debug.h"
@@ -128,6 +128,7 @@ WNDPROC wListView;  // all the lists use the same Proc
 // window resizing/docking variables
 unsigned CurXSize = 0;      // last known size of main client window
 unsigned CurYSize = 0;
+int      BytesCurSize = -1; // defaults to 125
 HCURSOR hCursResize;
 HCURSOR hCursDock;
 HCURSOR hCursArrow;
@@ -840,10 +841,12 @@ void RedrawColumns(int listnum)
     else if (listnum == ASM_WND)
     {
         // recalculate # of list items per page for all list windows
+        BytesCurSize = (BytesCurSize > 0) ? ListView_GetColumnWidth(hL[ASM_WND], 1) : 125;
         AsmPgSize = CallWindowProc(wListView,hL[ASM_WND],LVM_GETCOUNTPERPAGE,(WPARAM) 0,(LPARAM) 0);
         if (AsmPgSize != 0)
             ListLineRatio = ListVerticalPix / AsmPgSize;
-        CallWindowProc(wListView, hL[ASM_WND], LVM_SETCOLUMNWIDTH, 0, LVSCW_AUTOSIZE);
+        CallWindowProc(wListView, hL[ASM_WND], LVM_SETCOLUMNWIDTH, 0, LVSCW_AUTOSIZE_USEHEADER);
+        ListView_SetColumnWidth(hL[ASM_WND], 1, BytesCurSize);
     }
     else
     {


### PR DESCRIPTION
The 'bytes' column is automatically resized to the width of the word 'bytes' (its header). This makes most instruction rows show `...`.

This patch defaults the width to 125 pixels allowing you to resize it during each session. However, every new session will default back to 125. A new entry in the `bx_enh_dbg.ini` file could be created to save and restore this size instead of defaulting to 125 each time.

This patch is for Windows only. Other platforms may require other modifications.