### PR TITLE
UHCI: Fix erroneous frame number wrapping behaviour

### DIFF
--- a/bochs/iodev/usb/uhci_core.cc
+++ b/bochs/iodev/usb/uhci_core.cc
@@ -827,7 +827,7 @@ void bx_uhci_core_c::uhci_timer(void)
 
     // The Frame Number Register is incremented every 1ms
     hub.usb_frame_num.frame_num++;
-    hub.usb_frame_num.frame_num &= (1024-1);
+    hub.usb_frame_num.frame_num &= (2048-1);
 
     // The status.interrupt bit should be set regardless of the enable bits if a IOC or SPD is found
     if (interrupt || shortpacket) {


### PR DESCRIPTION
This PR fixes the frame number wrapping behaviour.

Previously it would incorrectly wrap around 1023 (0x3FF) instead of 2047 (0x7FF), causing behaviour to not match the specification. This PR makes it wrap around correctly.