### PR TITLE
BIOS: Fix register clobbering by int13_harddisk (#268)

### DIFF
--- a/bochs/bios/rombios.c
+++ b/bochs/bios/rombios.c
@@ -478,13 +478,21 @@ typedef unsigned long  Bit32u;
   ;; mul function
   lmull:
   lmulul:
-    and eax, #0x0000FFFF
-    shl ebx, #16
-    or  eax, ebx
+    push edx
+    push ebx
+    push eax
+    and  eax, #0x0000FFFF
+    shl  ebx, #16
+    or   eax, ebx
     SEG SS
-    mul eax, dword ptr [di]
-    mov ebx, eax
-    shr ebx, #16
+    mul  eax, dword ptr [di]
+    mov  edx, eax
+    pop  eax
+    mov  ax, dx
+    shr  edx, #16
+    pop  ebx
+    mov  bx, dx
+    pop  edx
     ret
 
   ;; dec function
@@ -513,11 +521,14 @@ typedef unsigned long  Bit32u;
   ;; tst function
   ltstl:
   ltstul:
-    and eax, #0x0000FFFF
-    shl ebx, #16
-    or  eax, ebx
-    shr ebx, #16
+    push eax
+    push ebx
+    and  eax, #0x0000FFFF
+    shl  ebx, #16
+    or   eax, ebx
     test eax, eax
+    pop  ebx
+    pop  eax
     ret
 
   ;; sr function
@@ -558,6 +569,9 @@ typedef unsigned long  Bit32u;
     ret
 
   ldivul:
+    push edx
+    push ebx
+    push eax
     and  eax, #0x0000FFFF
     shl  ebx, #16
     or   eax, ebx
@@ -568,8 +582,13 @@ typedef unsigned long  Bit32u;
     SEG SS
     mov  bx,  [di]
     div  ebx
-    mov  ebx, eax
-    shr  ebx, #16
+    mov  edx, eax
+    pop  eax
+    mov  ax, dx
+    shr  edx, #16
+    pop  ebx
+    mov  bx, dx
+    pop  edx
     ret
 
   imodu:
@@ -5671,8 +5690,8 @@ int13_edd(DS, SI, device)
 }
 
   void
-int13_harddisk(EHAX, DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS)
-  Bit16u EHAX, DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS;
+int13_harddisk(DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS)
+  Bit16u DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS;
 {
   Bit32u lba_low, lba_high;
   Bit16u cylinder, head, sector;
@@ -6536,8 +6555,8 @@ ASM_END
 }
 
   void
-int13_harddisk(EHAX, DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS)
-  Bit16u EHAX, DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS;
+int13_harddisk(DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS)
+  Bit16u DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS;
 {
   Bit8u    drive, num_sectors, sector, head, status, mod;
   Bit8u    drive_map;
@@ -9038,12 +9057,7 @@ int13_notcdrom:
 #endif
 
 int13_disk:
-  ;; int13_harddisk modifies high word of EAX
-  shr   eax, #16
-  push  ax
   call  _int13_harddisk
-  pop   ax
-  shl   eax, #16
 
 int13_out:
   pop ds


### PR DESCRIPTION
Issue: The high words of EAX, EBX and EDX are clobbered by int13_harddisk.

This can be checked by e.g. `TEST/DOSTEST.EXE` included with HX DOS Extender v2.21.

Affected games:
- Blackthorne (MS-DOS 6.22) shows corrupted player animations.
- others...

See also commit 140e2e9, 49736dd and 4d5d311.