### PR TITLE
Voodoo3: Fix single buffered rendering of triangles

### DIFF
--- a/bochs/iodev/display/voodoo_func.h
+++ b/bochs/iodev/display/voodoo_func.h
@@ -713,6 +713,8 @@ Bit32s triangle()
 
     case 1:   /* back buffer */
       drawbuf = (Bit16u *)(v->fbi.ram + v->fbi.rgboffs[v->fbi.backbuf]);
+      if (v->fbi.rgboffs[v->fbi.frontbuf] == v->fbi.rgboffs[v->fbi.backbuf])
+        v->fbi.video_changed = 1;
       break;
 
     default:  /* reserved */


### PR DESCRIPTION
Allows to run 3DMark 99 Max benchmarks with Single Frame Buffer option set. Uses the same idea as bfebb17 (#349).