### PR TITLE
Xhci dbg fix

### DIFF
--- a/bochs/config.cc
+++ b/bochs/config.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2002-2024  The Bochs Project
+//  Copyright (C) 2002-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -344,6 +344,11 @@ void bx_init_usb_debug_options(bx_list_c *base)
   new bx_param_bool_c(usb_debug,
     "doorbell", "Trigger on doorbell",
     "Trigger on Doorbell",
+    0
+  );
+  new bx_param_bool_c(usb_debug,
+    "data", "Trigger on data TRB",
+    "Trigger on data TRB",
     0
   );
   new bx_param_bool_c(usb_debug,

--- a/bochs/gui/gtk_usb_debug.cc
+++ b/bochs/gui/gtk_usb_debug.cc
@@ -1860,7 +1860,7 @@ int xhci_debug_dialog(int type, int param1)
 
 // USB debug dialog entry point
 
-int usb_debug_dialog(int type, int param1, int param2)
+int usb_debug_dialog(int type, Bit64u param0, int param1, int param2)
 {
   static bool first_call = true;
   int argc = 1, ret;

--- a/bochs/gui/gui.cc
+++ b/bochs/gui/gui.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2002-2024  The Bochs Project
+//  Copyright (C) 2002-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -715,7 +715,7 @@ void bx_gui_c::usb_handler(void)
   if (BX_GUI_THIS dialog_caps & BX_GUI_DLG_USB) {
     // Once we set the trigger, don't allow the user to press the button again
     if (SIM->get_param_num(BXPN_USB_DEBUG_START_FRAME)->get() < BX_USB_DEBUG_SOF_TRIGGER)
-      SIM->usb_debug_interface(USB_DEBUG_FRAME, 0, 0);
+      SIM->usb_debug_interface(USB_DEBUG_FRAME, 0, 0, 0);
   }
 }
 

--- a/bochs/gui/siminterface.cc
+++ b/bochs/gui/siminterface.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2002-2024  The Bochs Project
+//  Copyright (C) 2002-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -182,8 +182,8 @@ public:
   virtual int configuration_interface(const char* name, ci_command_t command);
 #if BX_USB_DEBUGGER
   virtual void register_usb_debug_type(int type);
-  virtual void usb_debug_trigger(int type, int trigger, int param1, int param2);
-  virtual int usb_debug_interface(int type, int param1, int param2);
+  virtual void usb_debug_trigger(int type, int trigger, Bit64u param0, int param1, int param2);
+  virtual int usb_debug_interface(int type, Bit64u param0, int param1, int param2);
 #endif
   virtual int begin_simulation(int argc, char *argv[]);
   virtual int register_runtime_config_handler(void *dev, rt_conf_handler_t handler);
@@ -943,18 +943,18 @@ void bx_real_sim_c::register_usb_debug_type(int type)
   usb_dbg_register_type(type);
 }
 
-void bx_real_sim_c::usb_debug_trigger(int type, int trigger, int param1, int param2)
+void bx_real_sim_c::usb_debug_trigger(int type, int trigger, Bit64u param0, int param1, int param2)
 {
-  usb_dbg_trigger(type, trigger, param1, param2);
+  usb_dbg_trigger(type, trigger, param0, param1, param2);
 }
 
-int bx_real_sim_c::usb_debug_interface(int type, int param1, int param2)
+int bx_real_sim_c::usb_debug_interface(int type, Bit64u param0, int param1, int param2)
 {
   int retval = -1;
 
   if (type != USB_DEBUG_NONE) {
     set_display_mode(DISP_MODE_CONFIG);
-    retval = usb_dbg_interface(type, param1, param2);
+    retval = usb_dbg_interface(type, param0, param1, param2);
     set_display_mode(DISP_MODE_SIM);
   }
   return retval;

--- a/bochs/gui/siminterface.h
+++ b/bochs/gui/siminterface.h
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2001-2024  The Bochs Project
+//  Copyright (C) 2001-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -565,6 +565,7 @@ enum {
 #define USB_DEBUG_NONEXIST 4
 #define USB_DEBUG_RESET    5
 #define USB_DEBUG_ENABLE   6
+#define USB_DEBUG_DATA     7
 
 #define BX_USB_DEBUG_SOF_NONE      0
 #define BX_USB_DEBUG_SOF_SET       1
@@ -732,8 +733,8 @@ public:
   virtual int configuration_interface(const char* name, ci_command_t command) {return -1; }
 #if BX_USB_DEBUGGER
   virtual void register_usb_debug_type(int type) {}
-  virtual void usb_debug_trigger(int type, int trigger, int param1, int param2) {}
-  virtual int usb_debug_interface(int type, int param1, int param2) { return -1; }
+  virtual void usb_debug_trigger(int type, int trigger, Bit64u param0, int param1, int param2) {}
+  virtual int usb_debug_interface(int type, Bit64u param0, int param1, int param2) { return -1; }
 #endif
   virtual int begin_simulation(int argc, char *argv[]) {return -1;}
   virtual int register_runtime_config_handler(void *dev, rt_conf_handler_t handler) {return 0;}

--- a/bochs/gui/usb_debug.cc
+++ b/bochs/gui/usb_debug.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C)      2023  Benjamin David Lunt
+//  Copyright (C)      2025  Benjamin David Lunt
 //  Copyright (C) 2003-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
@@ -230,7 +230,7 @@ void usb_dbg_register_type(int type)
   }
 }
 
-int usb_dbg_interface(int type, int param1, int param2)
+int usb_dbg_interface(int type, Bit64u param0, int param1, int param2)
 {
   if (SIM->get_param_enum(BXPN_USB_DEBUG_TYPE)->get() > 0) {
     // if "start_frame" is 0, do the debug_window
@@ -242,7 +242,7 @@ int usb_dbg_interface(int type, int param1, int param2)
       bx_gui->set_usbdbg_bitmap(1);
     } else {
       bx_gui->set_usbdbg_bitmap(0);
-      if (usb_debug_dialog(type, param1, param2) < 0) {
+      if (usb_debug_dialog(type, param0, param1, param2) < 0) {
         bx_user_quit = 1;
         bx_exit(1);
         return -1;
@@ -253,7 +253,7 @@ int usb_dbg_interface(int type, int param1, int param2)
 }
 
 // one of the controllers has triggered a debug item.
-void usb_dbg_trigger(int type, int trigger, int param1, int param2)
+void usb_dbg_trigger(int type, int trigger, Bit64u param0, int param1, int param2)
 {
   if ((usb_debug_type == USB_DEBUG_NONE) || (type != usb_debug_type))
     return;
@@ -264,7 +264,7 @@ void usb_dbg_trigger(int type, int trigger, int param1, int param2)
     case USB_DEBUG_FRAME:
       num_trigger = SIM->get_param_num(BXPN_USB_DEBUG_START_FRAME);
       if (num_trigger && (num_trigger->get() == BX_USB_DEBUG_SOF_TRIGGER)) {
-        SIM->usb_debug_interface(USB_DEBUG_FRAME, param1, param2);
+        SIM->usb_debug_interface(USB_DEBUG_FRAME, param0, param1, param2);
         num_trigger->set(BX_USB_DEBUG_SOF_SET);
       }
       break;
@@ -272,31 +272,37 @@ void usb_dbg_trigger(int type, int trigger, int param1, int param2)
     case USB_DEBUG_COMMAND:
       bool_trigger = SIM->get_param_bool(BXPN_USB_DEBUG_DOORBELL);
       if (bool_trigger && bool_trigger->get())
-        SIM->usb_debug_interface(USB_DEBUG_COMMAND, param1, param2);
+        SIM->usb_debug_interface(USB_DEBUG_COMMAND, param0, param1, param2);
+      break;
+
+    case USB_DEBUG_DATA:
+      bool_trigger = SIM->get_param_bool(BXPN_USB_DEBUG_DATA);
+      if (bool_trigger && bool_trigger->get())
+        SIM->usb_debug_interface(USB_DEBUG_DATA, param0, param1, param2);
       break;
 
     case USB_DEBUG_EVENT:
       bool_trigger = SIM->get_param_bool(BXPN_USB_DEBUG_EVENT);
       if (bool_trigger && bool_trigger->get())
-        SIM->usb_debug_interface(USB_DEBUG_EVENT, param1, param2);
+        SIM->usb_debug_interface(USB_DEBUG_EVENT, param0, param1, param2);
       break;
 
     case USB_DEBUG_NONEXIST:
       bool_trigger = SIM->get_param_bool(BXPN_USB_DEBUG_NON_EXIST);
       if (bool_trigger && bool_trigger->get())
-        SIM->usb_debug_interface(USB_DEBUG_NONEXIST, param1, param2);
+        SIM->usb_debug_interface(USB_DEBUG_NONEXIST, param0, param1, param2);
       break;
 
     case USB_DEBUG_RESET:
       bool_trigger = SIM->get_param_bool(BXPN_USB_DEBUG_RESET);
       if (bool_trigger && bool_trigger->get())
-        SIM->usb_debug_interface(USB_DEBUG_RESET, param1, param2);
+        SIM->usb_debug_interface(USB_DEBUG_RESET, param0, param1, param2);
       break;
 
     case USB_DEBUG_ENABLE:
       bool_trigger = SIM->get_param_bool(BXPN_USB_DEBUG_ENABLE);
       if (bool_trigger && bool_trigger->get())
-        SIM->usb_debug_interface(USB_DEBUG_ENABLE, param1, param2);
+        SIM->usb_debug_interface(USB_DEBUG_ENABLE, param0, param1, param2);
       break;
   }
 }

--- a/bochs/gui/usb_debug.h
+++ b/bochs/gui/usb_debug.h
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C)      2023  Benjamin David Lunt
+//  Copyright (C)      2025  Benjamin David Lunt
 //  Copyright (C) 2003-2025 The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
@@ -120,11 +120,11 @@ extern const char *ring_type[];
 // USB debug API
 void usb_dbg_register_type(int type);
 
-int usb_dbg_interface(int type, int param1, int param2);
+int usb_dbg_interface(int type, Bit64u param0, int param1, int param2);
 
-void usb_dbg_trigger(int type, int trigger, int param1, int param2);
+void usb_dbg_trigger(int type, int trigger, Bit64u param0, int param1, int param2);
 
-int usb_debug_dialog(int break_type, int param1, int param2);
+int usb_debug_dialog(int break_type, Bit64u param0, int param1, int param2);
 
 Bit32u get_pci_bar_addr(bx_shadow_data_c *pci_conf, Bit8u bar_num);
 

--- a/bochs/gui/win32usb.cc
+++ b/bochs/gui/win32usb.cc
@@ -67,7 +67,7 @@ HWND getBochsWindow()
 
 // return 0 to continue with emulation
 // return -1 to quit emulation
-int usb_debug_dialog(int break_type, int param1, int param2)
+int usb_debug_dialog(int break_type, Bit64u param0, int param1, int param2)
 {
   char str[COMMON_STR_SIZE];
   int ret;
@@ -111,6 +111,7 @@ int usb_debug_dialog(int break_type, int param1, int param2)
   // create the dialog and wait for it to return
   g_params.type = usb_debug_type;
   g_params.break_type = break_type;
+  g_params.zParam = param0;
   g_params.wParam = param1;
   g_params.lParam = param2;
   ret = (int) DialogBoxParam(NULL, MAKEINTRESOURCE(dlg_resource[usb_debug_type]), getBochsWindow(),
@@ -276,6 +277,7 @@ INT_PTR CALLBACK hc_uhci_callback(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPa
               SIM->get_param_bool(BXPN_USB_DEBUG_ENABLE)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_ENABLE) == BST_CHECKED) ? true : false);
               SIM->get_param_bool(BXPN_USB_DEBUG_DOORBELL)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_DOORBELL) == BST_CHECKED) ? true : false);
               SIM->get_param_bool(BXPN_USB_DEBUG_EVENT)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_EVENT) == BST_CHECKED) ? true : false);
+              SIM->get_param_bool(BXPN_USB_DEBUG_DATA)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_DATA) == BST_CHECKED) ? true : false);
               SIM->get_param_num(BXPN_USB_DEBUG_START_FRAME)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_SOF) == BST_CHECKED) ? BX_USB_DEBUG_SOF_SET : BX_USB_DEBUG_SOF_NONE);
               SIM->get_param_bool(BXPN_USB_DEBUG_NON_EXIST)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_NONEXIST) == BST_CHECKED) ? true : false);
               EndDialog(hDlg, 1);
@@ -364,6 +366,7 @@ int hc_uhci_init(HWND hwnd)
   CheckDlgButton(hwnd, IDC_DEBUG_ENABLE,   SIM->get_param_bool(BXPN_USB_DEBUG_ENABLE)->get() ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_DOORBELL, SIM->get_param_bool(BXPN_USB_DEBUG_DOORBELL)->get() ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_EVENT,    SIM->get_param_bool(BXPN_USB_DEBUG_EVENT)->get() ? BST_CHECKED : BST_UNCHECKED);
+  CheckDlgButton(hwnd, IDC_DEBUG_DATA,     SIM->get_param_bool(BXPN_USB_DEBUG_DATA)->get() ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_SOF,     (SIM->get_param_num(BXPN_USB_DEBUG_START_FRAME)->get() > BX_USB_DEBUG_SOF_NONE) ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_NONEXIST, SIM->get_param_bool(BXPN_USB_DEBUG_NON_EXIST)->get() ? BST_CHECKED : BST_UNCHECKED);
 
@@ -885,6 +888,7 @@ INT_PTR CALLBACK hc_xhci_callback(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPa
               SIM->get_param_bool(BXPN_USB_DEBUG_ENABLE)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_ENABLE) == BST_CHECKED) ? true : false);
               SIM->get_param_bool(BXPN_USB_DEBUG_DOORBELL)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_DOORBELL) == BST_CHECKED) ? true : false);
               SIM->get_param_bool(BXPN_USB_DEBUG_EVENT)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_EVENT) == BST_CHECKED) ? true : false);
+              SIM->get_param_bool(BXPN_USB_DEBUG_DATA)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_DATA) == BST_CHECKED) ? true : false);
               SIM->get_param_num(BXPN_USB_DEBUG_START_FRAME)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_SOF) == BST_CHECKED) ? BX_USB_DEBUG_SOF_SET : BX_USB_DEBUG_SOF_NONE);
               SIM->get_param_bool(BXPN_USB_DEBUG_NON_EXIST)->set((IsDlgButtonChecked(hDlg, IDC_DEBUG_NONEXIST) == BST_CHECKED) ? true : false);
               EndDialog(hDlg, 1);
@@ -932,6 +936,9 @@ INT_PTR CALLBACK hc_xhci_callback(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lPa
               switch (g_params.break_type) {
                 case USB_DEBUG_COMMAND:
                   xhci_display_trb(hDlg, VIEW_TRB_TYPE_COMMAND);
+                  break;
+                case USB_DEBUG_DATA:
+                  xhci_display_trb(hDlg, VIEW_TRB_TYPE_TRANSFER);
                   break;
                 case USB_DEBUG_EVENT:
                   xhci_display_trb(hDlg, VIEW_TRB_TYPE_EVENT);
@@ -1001,6 +1008,7 @@ int hc_xhci_init(HWND hwnd)
   CheckDlgButton(hwnd, IDC_DEBUG_ENABLE,   SIM->get_param_bool(BXPN_USB_DEBUG_ENABLE)->get() ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_DOORBELL, SIM->get_param_bool(BXPN_USB_DEBUG_DOORBELL)->get() ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_EVENT,    SIM->get_param_bool(BXPN_USB_DEBUG_EVENT)->get() ? BST_CHECKED : BST_UNCHECKED);
+  CheckDlgButton(hwnd, IDC_DEBUG_DATA,     SIM->get_param_bool(BXPN_USB_DEBUG_DATA)->get() ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_SOF,     (SIM->get_param_num(BXPN_USB_DEBUG_START_FRAME)->get() > BX_USB_DEBUG_SOF_NONE) ? BST_CHECKED : BST_UNCHECKED);
   CheckDlgButton(hwnd, IDC_DEBUG_NONEXIST, SIM->get_param_bool(BXPN_USB_DEBUG_NON_EXIST)->get() ? BST_CHECKED : BST_UNCHECKED);
 
@@ -1086,6 +1094,19 @@ int hc_xhci_init(HWND hwnd)
       hc_xhci_do_event_ring("Event", (int) g_params.wParam);
       EnableWindow(GetDlgItem(hwnd, IDC_VIEW_TRB), 1);
       valid = 1;
+      break;
+
+    // a TRB was placed on a data ring
+    case USB_DEBUG_DATA:
+      SetDlgItemText(hwnd, IDC_RING_TYPE, "Data Ring Address:");
+      RingPtr = g_params.zParam;
+      sprintf(str, "0x" FMT_ADDRX64, RingPtr);
+      SetDlgItemText(hwnd, IDC_FRAME_ADDRESS, str);
+      if (RingPtr != 0) {
+        hc_xhci_do_ring("Data", RingPtr, RingPtr);
+        EnableWindow(GetDlgItem(hwnd, IDC_VIEW_TRB), 1);
+        valid = 1;
+      }
       break;
 
     case USB_DEBUG_FRAME:

--- a/bochs/gui/win32usb.h
+++ b/bochs/gui/win32usb.h
@@ -27,6 +27,7 @@
 struct CALLBACK_PARAMS {
   int type;
   int break_type;
+  Bit64u zParam;
   int wParam;
   int lParam;
 };

--- a/bochs/gui/win32usbres.h
+++ b/bochs/gui/win32usbres.h
@@ -213,8 +213,9 @@
 #define IDC_DEBUG_ENABLE                8082
 #define IDC_DEBUG_DOORBELL              8083
 #define IDC_DEBUG_EVENT                 8084
-#define IDC_DEBUG_SOF                   8085
-#define IDC_DEBUG_NONEXIST              8086
+#define IDC_DEBUG_DATA                  8085
+#define IDC_DEBUG_SOF                   8086
+#define IDC_DEBUG_NONEXIST              8087
 
 #define IDC_TRB_DATA_PTR                  8100
 #define IDC_TRB_INT_TARGET                8101

--- a/bochs/iodev/usb/ohci_core.cc
+++ b/bochs/iodev/usb/ohci_core.cc
@@ -2,8 +2,8 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2009-2024  Benjamin D Lunt (fys [at] fysnet [dot] net)
-//                2009-2024  The Bochs Project
+//  Copyright (C) 2009-2025  Benjamin D Lunt (fys [at] fysnet [dot] net)
+//                2009-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -801,21 +801,21 @@ bool bx_ohci_core_c::mem_write(bx_phy_address addr, unsigned len, void *data)
     case 0x60: // HcRhPortStatus[3]
 #if (USB_OHCI_PORTS < 4)
   #if BX_USB_DEBUGGER
-      SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_NONEXIST, 0, 0);
+      SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_NONEXIST, 0, 0, 0);
   #endif
       break;
 #endif
     case 0x5C: // HcRhPortStatus[2]
 #if (USB_OHCI_PORTS < 3)
   #if BX_USB_DEBUGGER
-      SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_NONEXIST, 0, 0);
+      SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_NONEXIST, 0, 0, 0);
   #endif
       break;
 #endif
     case 0x58: // HcRhPortStatus[1]
 #if (USB_OHCI_PORTS < 2)
   #if BX_USB_DEBUGGER
-      SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_NONEXIST, 0, 0);
+      SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_NONEXIST, 0, 0, 0);
   #endif
       break;
 #endif
@@ -830,7 +830,7 @@ bool bx_ohci_core_c::mem_write(bx_phy_address addr, unsigned len, void *data)
           hub.usb_port[p].HcRhPortStatus.csc = 1;
         else {
 #if BX_USB_DEBUGGER
-          SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_ENABLE, 0, 0);
+          SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_ENABLE, 0, 0, 0);
 #endif
           hub.usb_port[p].HcRhPortStatus.pes = 1;
         }
@@ -849,7 +849,7 @@ bool bx_ohci_core_c::mem_write(bx_phy_address addr, unsigned len, void *data)
           hub.usb_port[p].HcRhPortStatus.csc = 1;
         else {
 #if BX_USB_DEBUGGER
-          SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_RESET, 0, 0);
+          SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_RESET, 0, 0, 0);
 #endif
           reset_port(p);
           hub.usb_port[p].HcRhPortStatus.pps = 1;
@@ -919,7 +919,7 @@ void bx_ohci_core_c::ohci_timer(void)
 
   if (hub.op_regs.HcControl.hcfs == OHCI_USB_OPERATIONAL) {
 #if BX_USB_DEBUGGER
-    SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_FRAME, 0, 0);
+    SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_FRAME, 0, 0, 0);
 #endif
     // set remaining to the interval amount.
     hub.op_regs.HcFmRemainingToggle = hub.op_regs.HcFmInterval.fit;
@@ -1161,7 +1161,7 @@ int bx_ohci_core_c::process_td(struct OHCI_TD *td, struct OHCI_ED *ed, int toggl
   }
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_COMMAND, 0, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_OHCI, USB_DEBUG_COMMAND, 0, 0, 0);
 #endif
 
   // The td->cc field should be 111x if it hasn't been processed yet.

--- a/bochs/iodev/usb/uhci_core.cc
+++ b/bochs/iodev/usb/uhci_core.cc
@@ -517,7 +517,7 @@ void bx_uhci_core_c::write(Bit32u address, Bit32u value, unsigned io_len)
       BX_ERROR(("write to non existent offset 0x14 (port #3)"));
 #if BX_USB_DEBUGGER
       // Non existant Register Port (the next one after the last)
-      SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_NONEXIST, 0, 0);
+      SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_NONEXIST, 0, 0, 0);
 #endif
       break;
 
@@ -530,7 +530,7 @@ void bx_uhci_core_c::write(Bit32u address, Bit32u value, unsigned io_len)
           break;
 #if BX_USB_DEBUGGER
         if ((value & (1 << 9)) && !hub.usb_port[port].reset)
-          SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_RESET, port, 0);
+          SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_RESET, 0, port, 0);
 #endif
         if (value & ((1<<5) | (1<<4) | (1<<0)))
           BX_DEBUG(("write to one or more read-only bits in port #%d register: 0x%04x", port+1, value));
@@ -558,7 +558,7 @@ void bx_uhci_core_c::write(Bit32u address, Bit32u value, unsigned io_len)
         hub.usb_port[port].resume = (value & (1<<6)) ? 1 : 0;
         if (!hub.usb_port[port].enabled && (value & (1<<2))) {
 #if BX_USB_DEBUGGER
-          SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_ENABLE, port, 0);
+          SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_ENABLE, 0, port, 0);
 #endif
           hub.usb_port[port].enable_changed = 0;
         } else
@@ -642,7 +642,7 @@ bool bx_uhci_core_c::uhci_add_queue(struct USB_UHCI_QUEUE_STACK *stack, const Bi
 void bx_uhci_core_c::uhci_timer(void)
 {
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_FRAME, 0, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_FRAME, 0, 0, 0);
 #endif
 
   // If the "global reset" bit was set by software
@@ -769,7 +769,7 @@ void bx_uhci_core_c::uhci_timer(void)
           DEV_MEM_WRITE_PHYSICAL(address + sizeof(Bit32u), sizeof(Bit32u), (Bit8u *) &td.dword1);
 #if BX_USB_DEBUGGER
           // trigger again so that the user can see the processed packet
-          SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_COMMAND, address, USB_LPARAM_FLAG_AFTER);
+          SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_COMMAND, 0, address, USB_LPARAM_FLAG_AFTER);
 #endif
           // we processed another td within this queue line
           td_count++;
@@ -921,7 +921,7 @@ bool bx_uhci_core_c::DoTransfer(Bit32u address, struct TD *td)
   BX_DEBUG(("TD found at address 0x%08X:  0x%08X  0x%08X  0x%08X  0x%08X", address, td->dword0, td->dword1, td->dword2, td->dword3));
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_COMMAND, address, USB_LPARAM_FLAG_BEFORE);
+  SIM->usb_debug_trigger(USB_DEBUG_UHCI, USB_DEBUG_COMMAND, 0, address, USB_LPARAM_FLAG_BEFORE);
 #endif
 
   // check TD to make sure it is valid

--- a/bochs/iodev/usb/usb_ehci.cc
+++ b/bochs/iodev/usb/usb_ehci.cc
@@ -4,7 +4,7 @@
 //
 //  Experimental USB EHCI adapter (partly ported from Qemu)
 //
-//  Copyright (C) 2015-2024  The Bochs Project
+//  Copyright (C) 2015-2025  The Bochs Project
 //
 //  Copyright(c) 2008  Emutex Ltd. (address@hidden)
 //  Copyright(c) 2011-2012 Red Hat, Inc.
@@ -1041,7 +1041,7 @@ bool bx_usb_ehci_c::write_handler(bx_phy_address addr, unsigned len, void *data,
                 BX_EHCI_THIS hub.usb_port[port].portsc.csc = 0;
                 if (BX_EHCI_THIS hub.usb_port[port].device->get_speed() == USB_SPEED_HIGH) {
 #if BX_USB_DEBUGGER
-                  SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_ENABLE, 0, 0);
+                  SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_ENABLE, 0, 0, 0);
 #endif
                   BX_EHCI_THIS hub.usb_port[port].portsc.ped = 1;
                 }
@@ -1049,7 +1049,7 @@ bool bx_usb_ehci_c::write_handler(bx_phy_address addr, unsigned len, void *data,
             }
 #if BX_USB_DEBUGGER
             if (!oldpr && BX_EHCI_THIS hub.usb_port[port].portsc.pr) {
-              SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_RESET, 0, 0);
+              SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_RESET, 0, 0, 0);
             }
 #endif
             if (oldfpr && !BX_EHCI_THIS hub.usb_port[port].portsc.fpr) {
@@ -1057,7 +1057,7 @@ bool bx_usb_ehci_c::write_handler(bx_phy_address addr, unsigned len, void *data,
             }
 #if BX_USB_DEBUGGER
           } else if (port == USB_EHCI_PORTS) {
-            SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_NONEXIST, 0, 0);
+            SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_NONEXIST, 0, 0, 0);
 #endif
           }
       }
@@ -1923,7 +1923,7 @@ int bx_usb_ehci_c::state_fetchqtd(EHCIQueue *q)
   int again = 0;
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_COMMAND, 0, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_COMMAND, 0, 0, 0);
 #endif
 
   get_dwords(NLPTR_GET(q->qtdaddr), (Bit32u*) &qtd, sizeof(EHCIqtd) >> 2);
@@ -2382,7 +2382,7 @@ void bx_usb_ehci_c::ehci_frame_timer(void)
   frames = (int)(usec_elapsed / FRAME_TIMER_USEC);
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_FRAME, 0, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_EHCI, USB_DEBUG_FRAME, 0, 0, 0);
 #endif
 
   if (BX_EHCI_THIS periodic_enabled() || (BX_EHCI_THIS hub.pstate != EST_INACTIVE)) {

--- a/bochs/iodev/usb/usb_uhci.cc
+++ b/bochs/iodev/usb/usb_uhci.cc
@@ -2,8 +2,8 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2009-2023  Benjamin D Lunt (fys [at] fysnet [dot] net)
-//                2009-2024  The Bochs Project
+//  Copyright (C) 2009-2025  Benjamin D Lunt (fys [at] fysnet [dot] net)
+//                2009-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public

--- a/bochs/iodev/usb/usb_xhci.cc
+++ b/bochs/iodev/usb/usb_xhci.cc
@@ -2,8 +2,8 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2010-2023  Benjamin D Lunt (fys [at] fysnet [dot] net)
-//                2011-2024  The Bochs Project
+//  Copyright (C) 2010-2025  Benjamin D Lunt (fys [at] fysnet [dot] net)
+//                2011-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -1851,7 +1851,7 @@ bool bx_usb_xhci_c::write_handler(bx_phy_address addr, unsigned len, void *data,
                (value & (1 << 4))) {
             reset_port_usb3(port, (value & (1 << 4)) ? HOT_RESET : WARM_RESET);
 #if BX_USB_DEBUGGER
-            SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_RESET, 0, 0);
+            SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_RESET, 0, 0, 0);
 #endif
           }
         } else
@@ -1918,7 +1918,7 @@ bool bx_usb_xhci_c::write_handler(bx_phy_address addr, unsigned len, void *data,
 #if BX_USB_DEBUGGER
   // Non existant Register Port (the next one after the last)
   else if (offset == (XHCI_PORT_SET_OFFSET + (BX_XHCI_THIS hub.n_ports * 16))) {
-    SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_NONEXIST, 0, 0);
+    SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_NONEXIST, 0, 0, 0);
   }
 #endif
 
@@ -2282,6 +2282,9 @@ Bit64u bx_usb_xhci_c::process_transfer_ring(int slot, int ep, Bit64u ring_addr, 
   // read in the TRB
   read_TRB((bx_phy_address) ring_addr, &trb);
   while ((trb.command & 1) == *rcs) {
+#if BX_USB_DEBUGGER
+    SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_DATA, ring_addr, 0, 0);
+#endif
     org_addr = ring_addr;
     BX_DEBUG(("Found TRB: address = 0x" FORMATADDRESS " 0x" FMT_ADDRX64 " 0x%08X 0x%08X  %d (SPD occurred = %d)",
       (bx_phy_address) org_addr, trb.parameter, trb.status, trb.command, *rcs, spd_occurred));
@@ -2547,7 +2550,7 @@ void bx_usb_xhci_c::process_command_ring(void)
   struct EP_CONTEXT   ep_context;
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_COMMAND, 0, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_COMMAND, 0, 0, 0);
 #endif
 
   if (!BX_XHCI_THIS hub.op_regs.HcCrcr.crr)
@@ -3064,7 +3067,7 @@ void bx_usb_xhci_c::write_event_TRB(unsigned interrupter, Bit64u parameter, Bit3
     command | (Bit32u) BX_XHCI_THIS hub.ring_members.event_rings[interrupter].rcs); // set the cycle bit
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_EVENT, interrupter, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_EVENT, 0, interrupter, 0);
 #endif
 
   BX_DEBUG(("Write Event TRB: table index: %d, trb index: %d",
@@ -3627,7 +3630,7 @@ void bx_usb_xhci_c::xhci_timer(void)
     return;
 
 #if BX_USB_DEBUGGER
-  SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_FRAME, 0, 0);
+  SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_FRAME, 0, 0, 0);
 #endif
 
   /* Per section 4.19.3 of the xHCI 1.0 specs, we need to present
@@ -3811,7 +3814,7 @@ bool bx_usb_xhci_c::set_connect_status(Bit8u port, bool connected)
     if (ped_org != BX_XHCI_THIS hub.usb_port[port].portsc.ped) {
       BX_XHCI_THIS hub.usb_port[port].portsc.pec = 1;
 #if BX_USB_DEBUGGER
-      SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_ENABLE, 0, 0);
+      SIM->usb_debug_trigger(USB_DEBUG_XHCI, USB_DEBUG_ENABLE, 0, 0, 0);
 #endif
     }
   }

--- a/bochs/param_names.h
+++ b/bochs/param_names.h
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2009-2024  The Bochs Project
+//  Copyright (C) 2009-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -141,6 +141,7 @@
 #define BXPN_USB_DEBUG_ENABLE            "ports.usb_debug.enable"
 #define BXPN_USB_DEBUG_START_FRAME       "ports.usb_debug.start_frame"
 #define BXPN_USB_DEBUG_DOORBELL          "ports.usb_debug.doorbell"
+#define BXPN_USB_DEBUG_DATA              "ports.usb_debug.data"
 #define BXPN_USB_DEBUG_EVENT             "ports.usb_debug.event"
 #define BXPN_USB_DEBUG_NON_EXIST         "ports.usb_debug.non_exist"
 #define BXPN_NE2K                        "network.ne2k"

--- a/bochs/win32res.rc
+++ b/bochs/win32res.rc
@@ -100,9 +100,9 @@ BEGIN
     PUSHBUTTON      "Cancel", IDCANCEL, 105, 40, 50, 14
 END
 
-#if BX_USB_DEBUGGER
+//#if BX_USB_DEBUGGER
 #include "win32usbres.rc"
-#endif
+//#endif
 #include "bxversion.rc"
 #if BX_DEBUGGER_GUI
 #include "win32_enh_dbg.rc"

--- a/bochs/win32res.rc
+++ b/bochs/win32res.rc
@@ -100,9 +100,9 @@ BEGIN
     PUSHBUTTON      "Cancel", IDCANCEL, 105, 40, 50, 14
 END
 
-//#if BX_USB_DEBUGGER
+#if BX_USB_DEBUGGER
 #include "win32usbres.rc"
-//#endif
+#endif
 #include "bxversion.rc"
 #if BX_DEBUGGER_GUI
 #include "win32_enh_dbg.rc"

--- a/bochs/win32usbres.rc
+++ b/bochs/win32usbres.rc
@@ -66,10 +66,12 @@ BEGIN
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,63,96,10
     CONTROL         "Event",IDC_DEBUG_EVENT,"Button",BS_AUTOCHECKBOX | 
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,73,96,10
-    CONTROL         "Start of Frame",IDC_DEBUG_SOF,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "Data",IDC_DEBUG_DATA,"Button",BS_AUTOCHECKBOX | 
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,83,96,10
-    CONTROL         "Non-exist",IDC_DEBUG_NONEXIST,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "Start of Frame",IDC_DEBUG_SOF,"Button",BS_AUTOCHECKBOX | 
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,93,96,10
+    CONTROL         "Non-exist",IDC_DEBUG_NONEXIST,"Button",BS_AUTOCHECKBOX | 
+                    BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,103,96,10
     CONTROL         "Tree1",IDC_STACK,"SysTreeView32",TVS_HASBUTTONS | 
                     TVS_HASLINES | TVS_DISABLEDRAGDROP | TVS_SHOWSELALWAYS | 
                     WS_BORDER | WS_TABSTOP,168,180,411,304
@@ -306,10 +308,12 @@ BEGIN
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,63,96,10
     CONTROL         "E&vent",IDC_DEBUG_EVENT,"Button",BS_AUTOCHECKBOX | 
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,73,96,10
-    CONTROL         "&Start of Frame",IDC_DEBUG_SOF,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "D&ata",IDC_DEBUG_DATA,"Button",BS_AUTOCHECKBOX | 
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,83,96,10
-    CONTROL         "&Non-exist",IDC_DEBUG_NONEXIST,"Button",BS_AUTOCHECKBOX | 
+    CONTROL         "&Start of Frame",IDC_DEBUG_SOF,"Button",BS_AUTOCHECKBOX | 
                     BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,93,96,10
+    CONTROL         "&Non-exist",IDC_DEBUG_NONEXIST,"Button",BS_AUTOCHECKBOX | 
+                    BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,491,103,96,10
     CONTROL         "Tree1",IDC_STACK,"SysTreeView32",TVS_HASBUTTONS | 
                     TVS_HASLINES | TVS_DISABLEDRAGDROP | TVS_SHOWSELALWAYS | 
                     WS_BORDER | WS_TABSTOP,168,180,411,304


### PR DESCRIPTION
The function for some of the xHCI rings was never added to the USB_DEBUGGER code.
This should now allow you to see the DATA rings as well.
Use the `data=1` parameter:
```
  usb_debug: type=xhci, doorbell=1, event=1, data=1
```
