### PR TITLE
Return 0x00 on reads less than a dword

### DIFF
--- a/bochs/iodev/hpet.cc
+++ b/bochs/iodev/hpet.cc
@@ -152,6 +152,12 @@ static bool hpet_read(bx_phy_address a20addr, unsigned len, void *data, void *pa
     value2 = theHPET->read_aligned(a20addr + 4);
     *((Bit64u *)data) = (value1 | (value2 << 32));
     return true;
+  } else if (len == 2) {
+    BX_ERROR(("Unsupported HPET read at address 0x" FMT_PHY_ADDRX " with len = 2", a20addr));
+    *((Bit16u *)data) = 0x0000;
+  } else if (len == 1) {
+    BX_ERROR(("Unsupported HPET read at address 0x" FMT_PHY_ADDRX " with len = 1", a20addr));
+    *((Bit8u *)data) = 0x00;
   } else {
     BX_PANIC(("Unsupported HPET read at address 0x" FMT_PHY_ADDRX " with len = %i", a20addr, len));
   }
@@ -175,6 +181,10 @@ static bool hpet_write(bx_phy_address a20addr, unsigned len, void *data, void *p
     Bit64u val64 = *((Bit64u*) data);
     theHPET->write_aligned(a20addr, (Bit32u)val64, false);
     theHPET->write_aligned(a20addr + 4, (Bit32u)(val64 >> 32), true);
+  } else if (len == 2) {
+    BX_ERROR(("Unsupported HPET write at address 0x" FMT_PHY_ADDRX " with len = 2", a20addr));
+  } else if (len == 1) {
+    BX_ERROR(("Unsupported HPET write at address 0x" FMT_PHY_ADDRX " with len = 1", a20addr));
   } else {
     BX_PANIC(("Unsupported HPET write at address 0x" FMT_PHY_ADDRX " with len = %i", a20addr, len));
   }


### PR DESCRIPTION
The HPET allows reads and writes of 32-bit and 64-bit on 32-bit and 64-bit boundaries only.
This patch returns 0x00 and 0x0000 respectively for these reads and ignores these writes, giving an error in the log file.
This patch still PANICs on other reads and writes.