### PR TITLE
fix and enhance harddrv

### DIFF
--- a/bochs/iodev/harddrv.h
+++ b/bochs/iodev/harddrv.h
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2001-2021  The Bochs Project
+//  Copyright (C) 2001-2025  The Bochs Project
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@
 
 #define MAX_MULTIPLE_SECTORS 16
 
+// SPC3r23.pdf, page 41
 typedef enum _sense {
   SENSE_NONE = 0, SENSE_NOT_READY = 2,
   SENSE_ILLEGAL_REQUEST = 5,
@@ -90,6 +91,7 @@ typedef struct {
   struct {
     bool reset;       // 0=normal, 1=reset controller
     bool disable_irq; // 0=allow irq, 1=disable irq
+    bool read_hob;    // 0=read legacy registers, 1=read hob registers
   } control;
   Bit8u    reset_in_progress;
   Bit8u    features;


### PR DESCRIPTION
- Fix the reading of the HOB registers
- return success on 0x37/0xF9 commands (still needs a little bit of work.)
- add the 0x46 (GET_CONFIG) command. This allows ReactOS 4.15.xxxx to boot in normal mode (LiveCD) LiveCD (Debug) still hangs. Most likely a different issue.
- the SENSE was not being cleared between commands. If one command failed, the next successful command would still show the failed SENSE values.