### PR TITLE
Try to make the fdc more like real hardware

### DIFF
--- a/bochs/iodev/floppy.cc
+++ b/bochs/iodev/floppy.cc
@@ -754,6 +754,12 @@ void bx_floppy_ctrl_c::write(Bit32u address, Bit32u value, unsigned io_len)
         // transition from NORMAL to RESET
         BX_FD_THIS s.main_status_reg = FD_MS_BUSY;
         BX_FD_THIS s.pending_command = FD_RESET; // RESET pending
+        // The following line allows ReactOS to recognize the floppy disk.
+        // ReactOS writes zero to the DOR when stopping the motor within its boot process
+        //   https://github.com/reactos/reactos/blob/master/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
+        //     DiskStopFloppyMotor() (At time of this writing, it is Line 780)
+        // ReactOS never sets the bit returning the controller to normal operation
+        //bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, FDC_TIMER_VAL, 0);
       }
       BX_FD_THIS s.DOR = value;
 

--- a/bochs/iodev/floppy.cc
+++ b/bochs/iodev/floppy.cc
@@ -754,12 +754,6 @@ void bx_floppy_ctrl_c::write(Bit32u address, Bit32u value, unsigned io_len)
         // transition from NORMAL to RESET
         BX_FD_THIS s.main_status_reg = FD_MS_BUSY;
         BX_FD_THIS s.pending_command = FD_RESET; // RESET pending
-        // The following line allows ReactOS to recognize the floppy disk.
-        // ReactOS writes zero to the DOR when stopping the motor within its boot process
-        //   https://github.com/reactos/reactos/blob/master/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
-        //     DiskStopFloppyMotor() (At time of this writing, it is Line 780)
-        // ReactOS never sets the bit returning the controller to normal operation
-        bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, FDC_TIMER_VAL, 0);
       }
       BX_FD_THIS s.DOR = value;
 

--- a/bochs/iodev/floppy.cc
+++ b/bochs/iodev/floppy.cc
@@ -754,12 +754,6 @@ void bx_floppy_ctrl_c::write(Bit32u address, Bit32u value, unsigned io_len)
         // transition from NORMAL to RESET
         BX_FD_THIS s.main_status_reg = FD_MS_BUSY;
         BX_FD_THIS s.pending_command = FD_RESET; // RESET pending
-        // The following line allows ReactOS to recognize the floppy disk.
-        // ReactOS writes zero to the DOR when stopping the motor within its boot process
-        //   https://github.com/reactos/reactos/blob/master/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
-        //     DiskStopFloppyMotor() (At time of this writing, it is Line 780)
-        // ReactOS never sets the bit returning the controller to normal operation
-        //bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, FDC_TIMER_VAL, 0);
       }
       BX_FD_THIS s.DOR = value;
 

--- a/bochs/iodev/floppy.cc
+++ b/bochs/iodev/floppy.cc
@@ -382,6 +382,7 @@ void bx_floppy_ctrl_c::reset(unsigned type)
   BX_FD_THIS s.status_reg1 = 0;
   BX_FD_THIS s.status_reg2 = 0;
   BX_FD_THIS s.status_reg3 = 0;
+  BX_FD_THIS s.lock = 1; // the lock bit is set by default
 
   // software reset (via DOR port 0x3f2 bit 2) does not change DOR
   if (type == BX_RESET_HARDWARE) {
@@ -393,10 +394,11 @@ void bx_floppy_ctrl_c::reset(unsigned type)
     // drive select 0
 
     // DIR and CCR affected only by hard reset
+    // Real hardware does not set the Disk Change bit after a reset
     for (int i=0; i<4; i++) {
-      BX_FD_THIS s.DIR[i] |= 0x80; // disk changed
+      BX_FD_THIS s.DIR[i] &= ~0x80; // disk changed = false
     }
-    BX_FD_THIS s.lock = 0;
+    BX_FD_THIS s.lock = 0; // hardware reset will clear the lock bit
   } else {
     BX_INFO(("controller reset in software"));
   }
@@ -521,7 +523,6 @@ void bx_floppy_ctrl_c::runtime_config(void)
 
 // static IO port read callback handler
 // redirects to non-static class handler to avoid virtual functions
-
 Bit32u bx_floppy_ctrl_c::read_handler(void *this_ptr, Bit32u address, unsigned io_len)
 {
 #if !BX_USE_FD_SMF
@@ -747,20 +748,27 @@ void bx_floppy_ctrl_c::write(Bit32u address, Bit32u value, unsigned io_len)
       }
       if (!prev_normal_operation && normal_operation) {
         // transition from RESET to NORMAL
-        bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, 250, 0);
+        BX_FD_THIS s.pending_command = FD_RESET; // RESET pending
+        bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, FDC_TIMER_VAL, 0);
       } else if (prev_normal_operation && !normal_operation) {
         // transition from NORMAL to RESET
         BX_FD_THIS s.main_status_reg = FD_MS_BUSY;
         BX_FD_THIS s.pending_command = FD_RESET; // RESET pending
+        // The following line allows ReactOS to recognize the floppy disk.
+        // ReactOS writes zero to the DOR when stopping the motor within its boot process
+        //   https://github.com/reactos/reactos/blob/master/boot/freeldr/freeldr/arch/i386/pc/pcdisk.c
+        //     DiskStopFloppyMotor() (At time of this writing, it is Line 780)
+        // ReactOS never sets the bit returning the controller to normal operation
+        bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, FDC_TIMER_VAL, 0);
       }
       BX_FD_THIS s.DOR = value;
 
       BX_DEBUG(("io_write: digital output register"));
       BX_DEBUG(("  motor on, drive0 = %d", motor_on_drive0 > 0));
       BX_DEBUG(("  motor on, drive1 = %d", motor_on_drive1 > 0));
-      BX_DEBUG(("  dma_and_interrupt_enable=%02x", (unsigned) dma_and_interrupt_enable));
-      BX_DEBUG(("  normal_operation=%02x", (unsigned) normal_operation));
-      BX_DEBUG(("  drive_select=%02x", (unsigned) drive_select));
+      BX_DEBUG(("  dma_and_interrupt_enable = %d", (unsigned) dma_and_interrupt_enable));
+      BX_DEBUG(("  normal_operation = %d", (unsigned) normal_operation));
+      BX_DEBUG(("  drive_select = %d", (unsigned) drive_select));
       if (BX_FD_THIS s.device_type[drive_select] == FDRIVE_NONE) {
         BX_DEBUG(("WARNING: non existing drive selected"));
       }
@@ -781,8 +789,9 @@ void bx_floppy_ctrl_c::write(Bit32u address, Bit32u value, unsigned io_len)
       BX_FD_THIS s.DSR = value & 0x7f;
       if (value & 0x80) {
         BX_FD_THIS s.main_status_reg &= FD_MS_NDMA;
+        BX_FD_THIS s.DOR = 0x0C;
         BX_FD_THIS s.pending_command = FD_RESET; // RESET pending
-        bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, 250, 0);
+        bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, FDC_TIMER_VAL, 0);
       }
       switch (BX_FD_THIS s.DSR & 0x03) {
         case 0: BX_DEBUG(("  500 Kbps")); break;
@@ -1079,7 +1088,7 @@ void bx_floppy_ctrl_c::floppy_command(void)
       BX_FD_THIS s.DOR &= ~FDC_DRV_MASK;
       BX_FD_THIS s.DOR |= drive;
       BX_DEBUG(("floppy_command(): recalibrate drive %u", (unsigned) drive));
-      step_delay = calculate_step_delay(drive, 0);
+      step_delay = calculate_step_delay(drive, 0) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, step_delay, 0);
       /* command head to track 0
        * controller set to non-busy
@@ -1132,7 +1141,7 @@ void bx_floppy_ctrl_c::floppy_command(void)
       BX_FD_THIS s.DOR |= drive;
 
       BX_FD_THIS s.head[drive] = (BX_FD_THIS s.command[1] >> 2) & 0x01;
-      step_delay = calculate_step_delay(drive, BX_FD_THIS s.command[2]);
+      step_delay = calculate_step_delay(drive, BX_FD_THIS s.command[2]) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, step_delay, 0);
       cylinder = BX_FD_THIS s.command[2];
 #if (FDC_CURRENT_TYPE & FDC_TYPE_DP8473)
@@ -1209,7 +1218,7 @@ void bx_floppy_ctrl_c::floppy_command(void)
       BX_DEBUG(("configure (no poll = %d)", (BX_FD_THIS s.command[2] & 0x10) ? 1 : 0));
       BX_DEBUG(("configure (fifothr = %d)", BX_FD_THIS s.command[2] & 0x0F));
       BX_DEBUG(("configure (pretrk  = %d)", BX_FD_THIS s.command[3]));
-      if (((BX_FD_THIS s.command[2] & 0x0F) > 0) && ((BX_FD_THIS s.command[2] & 0x0F) <= 15)) {
+      if (((BX_FD_THIS s.command[2] & 0x0F) >= 0) && ((BX_FD_THIS s.command[2] & 0x0F) <= 15)) {
         BX_FD_THIS s.config = BX_FD_THIS s.command[2];
       } else {
         BX_ERROR(("Illegal size for FIFO: %d (setting to 16)", (BX_FD_THIS s.command[2] & 0x0F) + 1));
@@ -1273,7 +1282,7 @@ void bx_floppy_ctrl_c::floppy_command(void)
       }
 
       // time to read one sector at 300 rpm
-      sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+      sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
       /* data reg not ready, controller busy */
       BX_FD_THIS s.main_status_reg &= FD_MS_NDMA;
@@ -1466,7 +1475,7 @@ void bx_floppy_ctrl_c::floppy_command(void)
           BX_FD_THIS s.main_status_reg |= (FD_MS_RQM | FD_MS_DIO);
         }
         // time to read one sector at 300 rpm
-        sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+        sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
         bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
       } else if ((BX_FD_THIS s.command[0] & 0x5f) == (FD_CMD_MFM | FD_CMD_WRITE_NORMAL_DATA)) {
         if (BX_FD_THIS s.media[drive].write_protected) {
@@ -1492,7 +1501,7 @@ void bx_floppy_ctrl_c::floppy_command(void)
         BX_FD_THIS s.main_status_reg &= FD_MS_NDMA;
         BX_FD_THIS s.main_status_reg |= FD_MS_BUSY;
         // time to verify one sector at 300 rpm
-        sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+        sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
         bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
       } else if (((BX_FD_THIS s.command[0] & 0x5f) == (FD_CMD_MFM | FD_CMD_SCAN_EQUAL)) ||
                  ((BX_FD_THIS s.command[0] & 0x5f) == (FD_CMD_MFM | FD_CMD_SCAN_LOW_EQUAL)) ||
@@ -1677,8 +1686,8 @@ void bx_floppy_ctrl_c::floppy_xfer(Bit8u drive, Bit32u offset, Bit8u *buffer, Bi
   if (BX_FD_THIS s.device_type[drive] == FDRIVE_NONE)
     BX_PANIC(("floppy_xfer: bad drive #%d", drive));
 
-  BX_DEBUG(("floppy_xfer: drive=%u, offset=%u, bytes=%u, direction=%s floppy",
-            drive, offset, bytes, (direction==FROM_FLOPPY)? "from" : "to"));
+  BX_DEBUG(("floppy_xfer: drive=%u, offset=%u (sector=%u), bytes=%u (sectors=%u), direction=%s floppy",
+            drive, offset, offset >> 9, bytes, bytes >> 9, (direction==FROM_FLOPPY)? "from" : "to"));
 
 #if BX_WITH_MACOS
   const char *pname = (drive == 0) ? BXPN_FLOPPYA_PATH : BXPN_FLOPPYB_PATH;
@@ -1742,7 +1751,7 @@ void bx_floppy_ctrl_c::timer_handler(void *this_ptr)
 void bx_floppy_ctrl_c::timer()
 {
   Bit8u motor_on;
-  
+
   Bit8u drive = BX_FD_THIS s.DOR & FDC_DRV_MASK;
   switch (BX_FD_THIS s.pending_command) {
     // recal
@@ -1889,7 +1898,7 @@ void bx_floppy_ctrl_c::timer()
       } else {
         increment_sector();
         // time to 'verify' one sector at 300 rpm
-        Bit32u sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+        Bit32u sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
         bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
       }
       break;
@@ -1917,7 +1926,7 @@ void bx_floppy_ctrl_c::timer()
       BX_FD_THIS raise_interrupt();
       BX_FD_THIS s.reset_sensei = 4;
       break;
-
+      
     // nothing pending?
     case FD_CMD_NOP:
       break;
@@ -1976,7 +1985,7 @@ Bit16u bx_floppy_ctrl_c::dma_write(Bit8u *buffer, Bit16u maxlen)
         DEV_dma_set_drq(FLOPPY_DMA_CHAN, 0);
       }
       // time to read one sector at 300 rpm
-      Bit32u sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+      Bit32u sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
     }
   }
@@ -2110,7 +2119,7 @@ Bit16u bx_floppy_ctrl_c::dma_read(Bit8u *buffer, Bit16u maxlen)
         DEV_dma_set_drq(FLOPPY_DMA_CHAN, 0);
       }
       // time to write one sector at 300 rpm
-      sector_time = (200000 / BX_FD_THIS s.media[drive].sectors_per_track) * fmt_sectors;
+      sector_time = ((FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * fmt_sectors) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
     }
     return retlen;
@@ -2144,7 +2153,7 @@ Bit16u bx_floppy_ctrl_c::dma_read(Bit8u *buffer, Bit16u maxlen)
       }
       // time to write one sector at 300 rpm
       increment_sector();
-      sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+      sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
     }
     return len;
@@ -2219,7 +2228,7 @@ Bit16u bx_floppy_ctrl_c::dma_read(Bit8u *buffer, Bit16u maxlen)
         enter_result_phase();
       }
       // time to write one sector at 300 rpm
-      sector_time = 200000 / BX_FD_THIS s.media[drive].sectors_per_track;
+      sector_time = (FDC_TIMER_VAL / BX_FD_THIS s.media[drive].sectors_per_track) * 1000;
       bx_pc_system.activate_timer(BX_FD_THIS s.floppy_timer_index, sector_time, 0);
     }
     return len;
@@ -2774,7 +2783,7 @@ void bx_floppy_ctrl_c::enter_result_phase(void)
         }
         BX_FD_THIS s.result[4] = (BX_FD_THIS s.SRT << 4) | BX_FD_THIS s.HUT;
         BX_FD_THIS s.result[5] = (BX_FD_THIS s.HLT << 1) | ((BX_FD_THIS s.main_status_reg & FD_MS_NDMA) ? 1 : 0);
-        BX_FD_THIS s.result[6] = BX_FD_THIS s.eot[drive];
+        BX_FD_THIS s.result[6] = (BX_FD_THIS s.eot[drive] > 0) ? BX_FD_THIS s.eot[drive] : BX_FD_THIS s.media[drive].sectors_per_track;
         BX_FD_THIS s.result[7] = (BX_FD_THIS s.lock << 7) | (BX_FD_THIS s.perp_mode & 0x7f);
         BX_FD_THIS s.result[8] = BX_FD_THIS s.config;
         BX_FD_THIS s.result[9] = BX_FD_THIS s.pretrk;
@@ -2807,7 +2816,7 @@ void bx_floppy_ctrl_c::enter_result_phase(void)
       case FD_CMD_LOCK_UNLOCK:
       // Lock command
       case FD_CMD_LOCK_UNLOCK | FD_CMD_LOCK:
-        BX_FD_THIS s.lock = (BX_FD_THIS s.pending_command & 0x80) > 0;
+        BX_FD_THIS s.lock = (BX_FD_THIS s.pending_command & FD_CMD_LOCK) > 0;
         BX_FD_THIS s.result_size = 1;
         BX_FD_THIS s.result[0] = (BX_FD_THIS s.lock << 4);
         break;
@@ -2970,6 +2979,13 @@ void bx_floppy_ctrl_c::enter_idle_phase(void)
   BX_FD_THIS s.floppy_buffer_index = 0;
 }
 
+// The SRT (Step Rate Interval) is the time interval between step pulses issued by the controller.
+// (1Meg: Programmable from 0.5 to 8 milliseconds in increments of 0.5ms)
+// (500k: Programmable from 1 to 16 milliseconds in increments of 1ms)
+// (300k: Programmable from 1.67 to 26.7 milliseconds in increments of 1.67ms)
+// (250k: Programmable from 2 to 32 milliseconds in increments of 2ms)
+// A SRT value of zero is the max delay with a value of 0xF as the shortest delay)
+// This function returns the count in milliseconds
 Bit32u bx_floppy_ctrl_c::calculate_step_delay(Bit8u drive, Bit8u new_cylinder)
 {
   Bit8u steps;
@@ -2979,7 +2995,7 @@ Bit32u bx_floppy_ctrl_c::calculate_step_delay(Bit8u drive, Bit8u new_cylinder)
     steps = abs(new_cylinder - BX_FD_THIS s.cylinder[drive]);
     reset_changeline();
   }
-  Bit32u one_step_delay = ((BX_FD_THIS s.SRT ^ 0x0f) + 1) * 500000 / drate_in_k[(BX_FD_THIS s.DSR & 0x03)];
+  Bit32u one_step_delay = ((BX_FD_THIS s.SRT ^ 0x0f) + 1) * 500 / drate_in_k[(BX_FD_THIS s.DSR & 0x03)];
   return (steps * one_step_delay);
 }
 

--- a/bochs/iodev/floppy.h
+++ b/bochs/iodev/floppy.h
@@ -115,6 +115,8 @@ enum {
 //  that we can only have 2 drives (which is the case at the moment)
 #define FDC_DRV_MASK 0x01  // set to 0x03 if you have 4 drives.
 
+#define FDC_TIMER_VAL  10
+
 #if BX_USE_FD_SMF
 #  define BX_FD_SMF  static
 #  define BX_FD_THIS theFloppyController->


### PR DESCRIPTION
- ~Create a "hack" to counter ReactOS clearing the reset bit and never restoring it to normal operation~
- Modify the source to return in milliseconds and then convert to microseconds for the timer
- Set DOR to normal operation after a reset via the Data Rate Select Register (0x3F4)
- Adjust the timing value to a smaller value (makes the floppy access faster)
- Real hardware sets the LOCK bit on by default
- Real hardware does not set the CHANGE DISK bit at reset
- Modified the BX_DEBUG for the DOR to print decimal instead of hex (value is bool, 0 or 1)
- Fix the `Illegal size for FIFO` error. Zero is a legal size on input, which translate to a size of 1.
- Added Sector numbers to the BX_DEBUG output of the `floppy_xfer` call.
- Fixed the `DUMP_REGISTERS` command to show the EOT value.