### PR TITLE
Keyboard and misc comments

### DIFF
--- a/bochs/.bochsrc
+++ b/bochs/.bochsrc
@@ -148,7 +148,7 @@
 #  arrow_lake                 15th Gen Intel(R) Core(TM) Ultra 5 245K (ArrowLake)
 #
 #  ADD_FEATURES:
-#    Enable one of more CPU feature in the CPU configuration selected by MODEL.
+#    Enable one or more CPU features in the CPU configuration selected by MODEL.
 #    Could be useful for testing CPU with newer imaginary configurations by
 #    adding a specific feature or set of features to existing MODEL. The list 
 #    of features to add supplied through space or comma separated string.

--- a/bochs/CHANGES
+++ b/bochs/CHANGES
@@ -74,6 +74,9 @@ Detailed change log :
     - UHCI fix: USBCMD and USBSTS register accept byte writes
     - Changing device connected to USB port on the command line works again.
       Port options are reset in that case.
+  - Keyboard
+    - Change a Panic to an Error when trying to add a byte to the out-buffer
+    - Added the 0xE1 (Secondary ID) command
 
 - GUI and display libraries
   - Fixed buffer overflow when using keymap feature

--- a/bochs/iodev/keyboard.cc
+++ b/bochs/iodev/keyboard.cc
@@ -786,7 +786,7 @@ void bx_keyb_c::controller_enQ(Bit8u data, unsigned source)
 void bx_keyb_c::kbd_enQ_imm(Bit8u val)
 {
   if (BX_KEY_THIS s.kbd_internal_buffer.num_elements >= BX_KBD_ELEMENTS) {
-    BX_PANIC(("internal keyboard buffer full (imm)"));
+    BX_ERROR(("internal keyboard buffer full (imm) trying to enqueue 0x%02X", val));
     return;
   }
   BX_KEY_THIS s.kbd_controller.kbd_output_buffer = val;
@@ -1307,6 +1307,12 @@ void bx_keyb_c::kbd_ctrl_to_mouse(Bit8u value)
         controller_enQ(BX_KEY_THIS s.mouse.get_resolution_byte(), 1); // resolution
         controller_enQ(BX_KEY_THIS s.mouse.sample_rate, 1); // sample rate
         BX_DEBUG(("mouse: get mouse information"));
+        break;
+
+      case 0xe1: // Read secondary ID
+        controller_enQ(0xFA, 1); // ACK
+        controller_enQ(0x00, 1); // 0 = unknown, 1 = IBM TrackPoint (with one more byte)
+        BX_DEBUG(("mouse: read secondary ID returning 0x00"));
         break;
 
       case 0xeb: // Read Data (send a packet when in Remote Mode)


### PR DESCRIPTION
- Change a Panic to an Error in keyboard.
- Added the Secondary ID command to the keyboard
  (This keeps Bochs from displaying an error to the log file)
- Fixed a grammar error in .bochrc
- Added the the CHANGES file