### PR TITLE
Add int13/0x0D

### DIFF
--- a/bochs/bios/rombios.c
+++ b/bochs/bios/rombios.c
@@ -5718,6 +5718,7 @@ int13_harddisk(DS, ES, DI, SI, BP, ELDX, BX, DX, CX, AX, IP, CS, FLAGS)
   switch (GET_AH()) {
 
     case 0x00: /* disk controller reset */
+    case 0x0D: /* disk controller reset */
       ata_reset (device);
       goto int13_success;
       break;


### PR DESCRIPTION
Simply adding service Int13h/0x0D
See https://github.com/fysnet/i440fx/issues/10
DOS 7.11 boots with rombios.c without this addition, but you may want to add it anyway.
I don't think there is anything different, as far as emulation is concerned, between service 0x00 and 0x0D.