### PR TITLE
Use system font on win32 dialog boxes

### DIFF
--- a/bochs/gui/win32paramdlg.cc
+++ b/bochs/gui/win32paramdlg.cc
@@ -348,23 +348,32 @@ int AskFilename(HWND hwnd, bx_param_filename_c *param, char *buffer)
 
 void InitDlgFont(void)
 {
-  LOGFONT LFont;
+    NONCLIENTMETRICS ncm = { 0 };
+    ncm.cbSize = sizeof(ncm);
 
-  LFont.lfHeight         = 8;                // Default logical height of font
-  LFont.lfWidth          = 0;                // Default logical average character width
-  LFont.lfEscapement     = 0;                // angle of escapement
-  LFont.lfOrientation    = 0;                // base-line orientation angle
-  LFont.lfWeight         = FW_NORMAL;        // font weight
-  LFont.lfItalic         = 0;                // italic attribute flag
-  LFont.lfUnderline      = 0;                // underline attribute flag
-  LFont.lfStrikeOut      = 0;                // strikeout attribute flag
-  LFont.lfCharSet        = DEFAULT_CHARSET;  // character set identifier
-  LFont.lfOutPrecision   = OUT_DEFAULT_PRECIS;  // output precision
-  LFont.lfClipPrecision  = CLIP_DEFAULT_PRECIS; // clipping precision
-  LFont.lfQuality        = DEFAULT_QUALITY;     // output quality
-  LFont.lfPitchAndFamily = DEFAULT_PITCH;     // pitch and family
-  lstrcpy(LFont.lfFaceName, "Helv");          // pointer to typeface name string
-  DlgFont  = CreateFontIndirect(&LFont);
+    if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(ncm), &ncm, 0)) {
+        DlgFont = CreateFontIndirect(&ncm.lfMessageFont);
+    }
+    // fallback for Windows Server 2003 and Windows XP/2000
+    else {
+        LOGFONT LFont;
+
+        LFont.lfHeight = 8;                          // Default logical height of font
+        LFont.lfWidth = 0;                           // Default logical average character width
+        LFont.lfEscapement = 0;                      // angle of escapement
+        LFont.lfOrientation = 0;                     // base-line orientation angle
+        LFont.lfWeight = FW_NORMAL;                  // font weight
+        LFont.lfItalic = 0;                          // italic attribute flag
+        LFont.lfUnderline = 0;                       // underline attribute flag
+        LFont.lfStrikeOut = 0;                       // strikeout attribute flag
+        LFont.lfCharSet = DEFAULT_CHARSET;           // character set identifier
+        LFont.lfOutPrecision = OUT_DEFAULT_PRECIS;   // output precision
+        LFont.lfClipPrecision = CLIP_DEFAULT_PRECIS; // clipping precision
+        LFont.lfQuality = DEFAULT_QUALITY;           // output quality
+        LFont.lfPitchAndFamily = DEFAULT_PITCH;      // pitch and family
+        lstrcpy(LFont.lfFaceName, "Helv");           // pointer to typeface name string
+        DlgFont = CreateFontIndirect(&LFont);
+    }
 }
 
 LRESULT CALLBACK EditHexWndProc(HWND Window, UINT msg, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
The win32 dialog box font is tiny on my 1920x1080 Windows laptop. 

![dialog_before](https://github.com/user-attachments/assets/88a8927a-68de-4a6c-a4c0-e83d45516834)

I have made the font less tiny by using the default system font instead.

![dialog_after](https://github.com/user-attachments/assets/56dae3b7-99b6-4372-8445-41977f8ed5e8)

Left fallback for that one person that wants to build it on Windows XP.
Reason for fallback: [NONCLIENTMETRICS#Remarks](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-nonclientmetricsa#remarks)