### PR TITLE
Fix missing colors in glxgears with NV40

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -158,6 +158,8 @@ struct gf_channel
   float d3d_scene_ambient_color[4];
   float d3d_viewport_offset[4];
   float d3d_viewport_scale[4];
+  Bit32u d3d_transform_program[544][4];
+  float d3d_transform_constant[512][4];
   float d3d_light_diffuse_color[8][3];
   float d3d_light_infinite_direction[8][3];
   float d3d_normal[3];
@@ -168,7 +170,7 @@ struct gf_channel
   bool d3d_triangle_done;
   Bit32u d3d_vertex_index;
   Bit32u d3d_attrib_index;
-  Bit32u d3d_data_index;
+  Bit32u d3d_comp_index;
   float d3d_vertex_data[3][16][4];
   Bit32u d3d_index_array_offset;
   Bit32u d3d_index_array_dma;
@@ -177,6 +179,10 @@ struct gf_channel
   Bit32u d3d_zstencil_clear_value;
   Bit32u d3d_color_clear_value;
   Bit32u d3d_clear_surface;
+  Bit32u d3d_transform_execution_mode;
+  Bit32u d3d_transform_program_load;
+  Bit32u d3d_transform_program_start;
+  Bit32u d3d_transform_constant_load;
 
   Bit8u  rop;
 


### PR DESCRIPTION
To make colors appear in glxgears with GeForce 6800 (NV40), partial implementation of vertex shaders was done.
Some vertex shader features may work for NV20 as well; NV35 support still needs to be done.
Also reliability of triangle rendering was improved, it may help with #577.
Slight glitch in gears geometry was left without fixing.

<img width="720" height="684" alt="Screenshot_2025-08-08_23-36-28" src="https://github.com/user-attachments/assets/a1ce4e75-cb78-43bc-a220-1cbf55b3c6f5" />
