### PR TITLE
Fix 3D test of DxDiag 4.08 with NV20

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -148,10 +148,13 @@ struct gf_channel
   Bit32u d3d_window_offset;
   Bit32u d3d_surface_color_offset;
   Bit32u d3d_surface_zeta_offset;
+  Bit32u d3d_cull_face_enable;
   Bit32u d3d_depth_test_enable;
   Bit32u d3d_lighting_enable;
   float d3d_clip_min;
   float d3d_clip_max;
+  Bit32u d3d_cull_face;
+  Bit32u d3d_front_face;
   Bit32u d3d_light_enable_mask;
   float d3d_inverse_model_view_matrix[12];
   float d3d_composite_matrix[16];
@@ -168,6 +171,7 @@ struct gf_channel
   Bit32u d3d_vertex_data_array_format[16];
   Bit32u d3d_begin_end;
   bool d3d_triangle_done;
+  bool d3d_triangle_flip;
   Bit32u d3d_vertex_index;
   Bit32u d3d_attrib_index;
   Bit32u d3d_comp_index;


### PR DESCRIPTION
Several changes were made to allow Direct3D test from DxDiag 4.08 to display correct 3D cube with GeForce 3.
* Implemented face culling;
* Fixed depth buffer writes;
* Added `TRIANGLE_STRIP` support.

<img width="650" height="564" alt="Screenshot_2025-08-11_00-00-18" src="https://github.com/user-attachments/assets/972f3d8f-34f9-4989-8f19-c3b3d97710a9" />
