### PR TITLE
Implement vertex shaders for NV35

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -113,6 +113,7 @@ struct gf_channel
   Bit32u blit_hw;
 
   Bit32u sifm_src;
+  bool sifm_swizzled;
   Bit32u sifm_operation;
   Bit32u sifm_color_fmt;
   Bit32u sifm_color_bytes;


### PR DESCRIPTION
This change implements enough features of vertex shaders to run [VertexShader](https://github.com/user-attachments/files/21750901/VertexShader.zip) test from DirectX SDK with GeForce FX 5900.
For it to run, DirectX 8 or later should be installed.

<img width="650" height="564" alt="Screenshot_2025-08-13_11-48-00" src="https://github.com/user-attachments/assets/95167c64-2325-464a-86ee-ba8fe4b2712b" />
