### PR TITLE
Fix GeForce screen updates with 309.08 driver

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -456,6 +456,7 @@ private:
   Bit32u class_mask;
 
   Bit8u *disp_ptr;
+  Bit32u disp_offset;
   Bit32u bank_base[2];
 
   struct {


### PR DESCRIPTION
New GeForce driver for Windows 7 (309.08) uses M2MF methods for copying of screen data instead of SIFM, used by default driver.
This change fixes incorrect screen updates caused by wrong offset calculation for M2MF methods.