### PR TITLE
Fix colors of DirectDraw test from DxDiag 4.09 with NV40

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -114,6 +114,17 @@ struct gf_channel
   Bit32u blit_dyx;
   Bit32u blit_hw;
 
+  bool tfc_swizzled;
+  Bit32u tfc_color_fmt;
+  Bit32u tfc_color_bytes;
+  Bit32u tfc_yx;
+  Bit32u tfc_hw;
+  Bit32u tfc_clip_wx;
+  Bit32u tfc_clip_hy;
+  Bit32u tfc_words_ptr;
+  Bit32u tfc_words_left;
+  Bit32u* tfc_words;
+
   Bit32u sifm_src;
   bool sifm_swizzled;
   Bit32u sifm_operation;
@@ -139,6 +150,8 @@ struct gf_channel
   Bit32u m2mf_format;
   Bit32u m2mf_buffer_notify;
 
+  Bit32u d3d_a_obj;
+  Bit32u d3d_b_obj;
   Bit32u d3d_color_obj;
   Bit32u d3d_zeta_obj;
   Bit32u d3d_vertex_a_obj;
@@ -331,6 +344,7 @@ private:
 
   BX_GEFORCE_SMF void update_color_bytes_ifc(gf_channel* ch);
   BX_GEFORCE_SMF void update_color_bytes_sifc(gf_channel* ch);
+  BX_GEFORCE_SMF void update_color_bytes_tfc(gf_channel* ch);
   BX_GEFORCE_SMF void update_color_bytes_iifc(gf_channel* ch);
   BX_GEFORCE_SMF void update_color_bytes(Bit32u s2d_color_fmt, Bit32u color_fmt, Bit32u* color_bytes);
 
@@ -346,6 +360,7 @@ private:
   BX_GEFORCE_SMF void execute_iifc(gf_channel* ch, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_sifc(gf_channel* ch, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_beta(gf_channel* ch, Bit32u method, Bit32u param);
+  BX_GEFORCE_SMF void execute_tfc(gf_channel* ch, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_sifm(gf_channel* ch, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_d3d(gf_channel* ch, Bit32u cls, Bit32u method, Bit32u param);
 
@@ -360,6 +375,7 @@ private:
   BX_GEFORCE_SMF void iifc(gf_channel* ch);
   BX_GEFORCE_SMF void sifc(gf_channel* ch);
   BX_GEFORCE_SMF void copyarea(gf_channel* ch);
+  BX_GEFORCE_SMF void tfc(gf_channel* ch);
   BX_GEFORCE_SMF void m2mf(gf_channel* ch);
   BX_GEFORCE_SMF void sifm(gf_channel* ch);
 


### PR DESCRIPTION
DirectDraw test from DirectX 9 uses 3D triangles and pixel shaders of GeForce 6800 to render 2D rectangles.
This change implements pixel shader features to get correct black and white colors in such test:
<img width="650" height="564" alt="Screenshot_2025-08-20_00-05-09" src="https://github.com/user-attachments/assets/95b5853b-a36f-4d9b-91b8-b363dba6637b" />

With some drivers only one triangle of the pair is rendered, this problem is not related to pixel shaders.
Also emulation of pixel shaders is slow right now. It can be partially fixed by smarter algorithms, but for now it is more important to improve correctness.