### PR TITLE
Fix crash with GeForce driver 307.83 in Windows XP

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -156,6 +156,7 @@ struct gf_channel
   Bit32u d3d_zeta_obj;
   Bit32u d3d_vertex_a_obj;
   Bit32u d3d_vertex_b_obj;
+  Bit32u d3d_report_obj;
   Bit32u d3d_clip_horizontal;
   Bit32u d3d_clip_vertical;
   Bit32u d3d_surface_format;


### PR DESCRIPTION
When DirectX-based program is started in Windows XP with 307.83 GeForce driver installed, driver crashes and operating system switches to 16 color mode.
This change partially implements `GET_REPORT` method, which driver relies on.
Also several cases of missing triangles are fixed.