### PR TITLE
Make text visible in Ubuntu 10.04 with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -209,9 +209,11 @@ struct gf_channel
   float d3d_vertex_data[4][16][4];
   Bit32u d3d_index_array_offset;
   Bit32u d3d_index_array_dma;
-  Bit32u d3d_texture_offset[4];
-  Bit32u d3d_texture_format[4];
-  Bit32u d3d_texture_image_rect[4];
+  Bit32u d3d_texture_offset[16];
+  Bit32u d3d_texture_format[16];
+  Bit32u d3d_texture_control1[16];
+  Bit32u d3d_texture_image_rect[16];
+  Bit32u d3d_texture_control3[16];
   Bit32u d3d_semaphore_obj;
   Bit32u d3d_semaphore_offset;
   Bit32u d3d_zstencil_clear_value;


### PR DESCRIPTION
This change allows Ubuntu 10.04.4 to display 3D accelerated text with NV35 and NV40 cards.
Also it allows to render [Basic WebGL - Triangle](https://webglworkshop.com/26/01-triangle.html) page with Firefox.

<img width="650" height="564" alt="Screenshot_2025-09-03_09-51-04" src="https://github.com/user-attachments/assets/f83014c2-9668-4315-9772-d34fc439e3b6" />
<img width="650" height="564" alt="Screenshot_2025-09-03_09-57-56" src="https://github.com/user-attachments/assets/af854e62-500f-4fc8-82f4-ab2caa6eb8f0" />
