### PR TITLE
Partial fix for Windows Aero with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -224,7 +224,7 @@ struct gf_channel
   Bit32u d3d_transform_program_start;
   Bit32u d3d_transform_constant_load;
   Bit32u d3d_attrib_color;
-  Bit32u d3d_attrib_tex_coord;
+  Bit32u d3d_attrib_tex_coord[10];
 
   Bit8u  rop;
 


### PR DESCRIPTION
This change allows to see contents of application windows when Windows 7 is in Aero mode.

<img width="720" height="660" alt="Screenshot_2025-09-03_18-21-16" src="https://github.com/user-attachments/assets/fa231fd4-7e21-4795-adf5-a3f8a7b29bda" />
