### PR TITLE
Fix mirrored text in Blin with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -248,6 +248,7 @@ struct gf_channel
 
   Bit32u gdi_operation;
   Bit32u gdi_color_fmt;
+  Bit32u gdi_mono_fmt;
   Bit32u gdi_clip_yx0;
   Bit32u gdi_clip_yx1;
   Bit32u gdi_rect_color;


### PR DESCRIPTION
This change fixes two problems with Blin (#599): in some places text was mirrored, in other places it was missing.