### PR TITLE
Fix missing UI elements in XFree86 4.3.0 with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -61,6 +61,7 @@ struct gf_channel
   bool notify_pending;
   Bit32u notify_type;
 
+  bool s2d_locked;
   Bit32u s2d_img_src;
   Bit32u s2d_img_dst;
   Bit32u s2d_color_fmt;
@@ -469,6 +470,8 @@ private:
   Bit32u graph_notify;
   Bit32u graph_fifo;
   Bit32u graph_channel_ctx_table;
+  Bit32u graph_offset0;
+  Bit32u graph_pitch0;
   Bit32u crtc_intr;
   Bit32u crtc_intr_en;
   Bit32u crtc_start;


### PR DESCRIPTION
This change allows 2D acceleration to work with old GeForce drivers like XFree86 4.3.0.
Here is how Dyne:bolic 1.4.1 (#604) looks with this change applied:
<img width="650" height="564" alt="Screenshot_2025-09-10_00-03-34" src="https://github.com/user-attachments/assets/ec7b4850-6b31-4e6d-b57f-c3a0414e4062" />
