### PR TITLE
Implement texture addressing modes for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -217,6 +217,7 @@ struct gf_channel
   Bit32u d3d_index_array_dma;
   Bit32u d3d_texture_offset[16];
   Bit32u d3d_texture_format[16];
+  Bit32u d3d_texture_address[16];
   Bit32u d3d_texture_control1[16];
   Bit32u d3d_texture_image_rect[16];
   Bit32u d3d_texture_control3[16];
@@ -410,7 +411,7 @@ private:
   BX_GEFORCE_SMF void d3d_clear_surface(gf_channel* ch);
   BX_GEFORCE_SMF void d3d_transform(gf_channel* ch, float v[4]);
   BX_GEFORCE_SMF void d3d_sample_texture(gf_channel* ch,
-    Bit32u tex_unit, float s, float t, float r, float color[4]);
+    Bit32u tex_unit, float str[3], float color[4]);
   BX_GEFORCE_SMF void d3d_vertex_shader(gf_channel* ch, float in[16][4], float out[16][4]);
   BX_GEFORCE_SMF void d3d_pixel_shader(gf_channel* ch, float in[16][4], float tmp_regs16[64][4], float tmp_regs32[64][4]);
   static float d3d_blend(gf_channel* ch, Bit32u factor, float src_rgb, float src_a, float dst_rgb, float dst_a);


### PR DESCRIPTION
This change allows textures to be visible in Half-Life v45/1.1.0.8.
Also it fixes rendering of long pages in 3D accelerated Firefox.

Known problems which are not solved yet:
* Texture distortion (perspective correction is not implemented);
* Texture corruption (reasons unknown).
<img width="650" height="564" alt="Screenshot_2025-09-11_16-32-35" src="https://github.com/user-attachments/assets/6138da41-4545-47f8-9bac-9bcf16e27ec6" />
<img width="650" height="564" alt="Screenshot_2025-09-11_17-31-06" src="https://github.com/user-attachments/assets/7a8e5373-70eb-4c40-a1b3-50439c47373a" />
