### PR TITLE
Implement perspective-correct interpolation for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -201,6 +201,7 @@ struct gf_channel
   float d3d_light_infinite_direction[8][3];
   float d3d_normal[3];
   float d3d_diffuse_color[4];
+  float d3d_texcoord[4][4];
   Bit32u d3d_vertex_data_array_offset[16];
   Bit32u d3d_vertex_data_array_format_type[16];
   Bit32u d3d_vertex_data_array_format_size[16];
@@ -218,6 +219,7 @@ struct gf_channel
   Bit32u d3d_texture_offset[16];
   Bit32u d3d_texture_format[16];
   Bit32u d3d_texture_address[16];
+  Bit32u d3d_texture_control0[16];
   Bit32u d3d_texture_control1[16];
   Bit32u d3d_texture_image_rect[16];
   Bit32u d3d_texture_control3[16];


### PR DESCRIPTION
This change allows to fix texture distortion visible in Half-Life and 3DMark 99.
Also it adds basic texture support for NV20.

<img width="650" height="564" alt="Screenshot_2025-09-17_12-29-26" src="https://github.com/user-attachments/assets/69b26455-2853-4d35-b0c7-5345dd11d4bd" />
<img width="650" height="564" alt="Screenshot_2025-09-17_12-35-46" src="https://github.com/user-attachments/assets/5f8b3513-c49c-40e1-88f2-c77d66345cf2" />
