### PR TITLE
Fix textures corruption in Half-Life with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -73,6 +73,8 @@ struct gf_channel
   Bit32u swzs_img_obj;
   Bit32u swzs_fmt;
   Bit32u swzs_color_bytes;
+  Bit32u swzs_width;
+  Bit32u swzs_height;
   Bit32u swzs_ofs;
 
   bool ifc_color_key_enable;


### PR DESCRIPTION
This change fixes swizzle calculations for non-square textures, which allows to get rid of textures corruption in Half-Life (for example, "BLACK MESA RESEARCH FACILITY" text is now rendered correctly).

<img width="650" height="564" alt="Screenshot_2025-09-18_09-25-18" src="https://github.com/user-attachments/assets/7e36fb1f-0aba-4fff-a7a0-ac3ea1968dac" />
