### PR TITLE
Implement depth comparison function for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -132,6 +132,8 @@ struct gf_channel
   Bit32u tfc_words_ptr;
   Bit32u tfc_words_left;
   Bit32u* tfc_words;
+  bool tfc_upload;
+  Bit32u tfc_upload_offset;
 
   Bit32u sifm_src;
   bool sifm_swizzled;
@@ -180,7 +182,9 @@ struct gf_channel
   Bit32u d3d_blend_func_dfactor;
   Bit32u d3d_cull_face_enable;
   Bit32u d3d_depth_test_enable;
+  Bit32u d3d_depth_write_enable;
   Bit32u d3d_lighting_enable;
+  Bit32u d3d_depth_func;
   Bit32u d3d_shade_mode;
   float d3d_clip_min;
   float d3d_clip_max;
@@ -224,6 +228,7 @@ struct gf_channel
   Bit32u d3d_texture_control0[16];
   Bit32u d3d_texture_control1[16];
   Bit32u d3d_texture_image_rect[16];
+  Bit32u d3d_texture_palette[16];
   Bit32u d3d_texture_control3[16];
   Bit32u d3d_semaphore_obj;
   Bit32u d3d_semaphore_offset;


### PR DESCRIPTION
Proper implementation of depth comparison allows lightmaps in Half-Life to be visible.
Additionally, this commit fixes lighting in DxDiag 9 Direct3D 8 cube with NV35 and 81.98 driver.
Also it contains implementation for indexed color textures (`I8_A8R8G8B8`).
<img width="650" height="564" alt="Screenshot_2025-09-20_08-05-26" src="https://github.com/user-attachments/assets/bf9ba81c-4cf1-4ee6-a1bf-85bdc5b28dce" />
