### PR TITLE
Implement signed texture formats for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -144,8 +144,8 @@ struct gf_channel
   Bit32u sifm_dyx;
   Bit32u sifm_shw;
   Bit32u sifm_dhw;
-  Bit32u sifm_dudx;
-  Bit32u sifm_dvdy;
+  Bit32s sifm_dudx;
+  Bit32s sifm_dvdy;
   Bit32u sifm_sfmt;
   Bit32u sifm_sofs;
 
@@ -227,6 +227,7 @@ struct gf_channel
   Bit32u d3d_texture_address[16];
   Bit32u d3d_texture_control0[16];
   Bit32u d3d_texture_control1[16];
+  Bit32u d3d_texture_filter[16];
   Bit32u d3d_texture_image_rect[16];
   Bit32u d3d_texture_palette[16];
   Bit32u d3d_texture_control3[16];


### PR DESCRIPTION
This change adds support for signed formats like `D3DFMT_V8U8`, allowing lens effect from [BumpLens](https://github.com/user-attachments/files/22571416/BumpLens.zip) program to work correctly (with NV40 and 81.98 driver).
Additionally, this code:
* Allows Firefox icon in Ubuntu 10.04.4 to be displayed with correct colors;
* Adds basic implementation for SIFM scaling.

<img width="650" height="564" alt="Screenshot_2025-09-27_09-33-23" src="https://github.com/user-attachments/assets/ed5cc7f3-5d9e-4e04-9883-f7b94d4bff3e" />
<img width="650" height="564" alt="Screenshot_2025-09-27_09-23-36" src="https://github.com/user-attachments/assets/aeb8b444-07be-41c8-8016-64a2c76b42ad" />
