### PR TITLE
Implement near clipping plane for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -241,7 +241,9 @@ struct gf_channel
   Bit32u d3d_transform_program_start;
   Bit32u d3d_transform_constant_load;
   Bit32u d3d_attrib_color;
+  Bit32u d3d_dci;
   Bit32u d3d_attrib_tex_coord[10];
+  Bit32u d3d_tex_coord_count;
 
   Bit8u  rop;
 
@@ -419,13 +421,14 @@ private:
   BX_GEFORCE_SMF void sifm(gf_channel* ch);
 
   BX_GEFORCE_SMF void d3d_clear_surface(gf_channel* ch);
-  BX_GEFORCE_SMF void d3d_transform(gf_channel* ch, float v[4]);
   BX_GEFORCE_SMF void d3d_sample_texture(gf_channel* ch,
     Bit32u tex_unit, float str[3], float color[4]);
   BX_GEFORCE_SMF void d3d_vertex_shader(gf_channel* ch, float in[16][4], float out[16][4]);
   BX_GEFORCE_SMF void d3d_pixel_shader(gf_channel* ch, float in[16][4], float tmp_regs16[64][4], float tmp_regs32[64][4]);
   static float d3d_blend(gf_channel* ch, Bit32u factor, float src_rgb, float src_a, float dst_rgb, float dst_a);
   BX_GEFORCE_SMF void d3d_triangle(gf_channel* ch, Bit32u base);
+  BX_GEFORCE_SMF void d3d_triangle_clipped(gf_channel* ch, float v0[16][4], float v1[16][4], float v2[16][4]);
+  BX_GEFORCE_SMF void d3d_clip_to_screen(gf_channel* ch, float pos_clip[4], float pos_screen[4]);
   BX_GEFORCE_SMF void d3d_process_vertex(gf_channel* ch);
   BX_GEFORCE_SMF void d3d_load_vertex(gf_channel* ch, Bit32u index);
   BX_GEFORCE_SMF Bit32u d3d_get_surface_pitch_z(gf_channel* ch);


### PR DESCRIPTION
Some 4D triangles can't be directly projected into 2D triangles. It is possible however after the clipping process, which requires creation of additional triangle sometimes.
This change fixes rendering of [BillBoard](https://github.com/user-attachments/files/22600530/BillBoard.zip) program. Also Half-Life in OpenGL mode looks correct now.
<img width="650" height="564" alt="Screenshot_2025-09-29_18-00-32" src="https://github.com/user-attachments/assets/53b040a1-7576-49fb-a848-b82d1fcb48c6" />
