### PR TITLE
give error if read from non-powered port

### DIFF
--- a/bochs/iodev/usb/usb_xhci.cc
+++ b/bochs/iodev/usb/usb_xhci.cc
@@ -1376,6 +1376,7 @@ bool bx_usb_xhci_c::read_handler(bx_phy_address addr, unsigned len, void *data, 
       }
     }
     else {
+      BX_ERROR(("Read from port %d when portsc.pp = 0", port));
       val = 0;
     }
   }


### PR DESCRIPTION
Simply give an error to the log file if trying to read from a non-powered port.