### PR TITLE
Implement alpha testing for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -178,6 +178,9 @@ struct gf_channel
   Bit16s d3d_window_offset_y;
   Bit32u d3d_surface_color_offset;
   Bit32u d3d_surface_zeta_offset;
+  Bit32u d3d_alpha_test_enable;
+  Bit32u d3d_alpha_func;
+  Bit32u d3d_alpha_ref;
   Bit32u d3d_blend_enable;
   Bit16u d3d_blend_sfactor_rgb;
   Bit16u d3d_blend_sfactor_alpha;


### PR DESCRIPTION
This change allows Unreal version 226 to display its logo correctly in Direct3D mode.
<img width="650" height="564" alt="Screenshot_2025-10-09_19-39-13" src="https://github.com/user-attachments/assets/d3b8b618-2ef8-4658-8f06-42060e2c8c71" />
