### PR TITLE
Basic implementation of chroma key for textures with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -253,6 +253,7 @@ struct gf_channel
   Bit32u d3d_texture_image_rect[16];
   Bit32u d3d_texture_palette[16];
   Bit32u d3d_texture_control3[16];
+  Bit32u d3d_texture_key_color[16];
   Bit32u d3d_semaphore_obj;
   Bit32u d3d_semaphore_offset;
   Bit32u d3d_zstencil_clear_value;


### PR DESCRIPTION
This change allows text in Frogger 2 with NV40 to have correct shape and color.
Additionally, check, which prevents out of bounds VRAM access, is added (issue #636).
<img width="650" height="564" alt="Screenshot_2025-10-17_23-00-37" src="https://github.com/user-attachments/assets/4da43924-2dfc-4dbc-ac89-92e728c4f219" />
<img width="650" height="564" alt="Screenshot_2025-10-17_23-01-22" src="https://github.com/user-attachments/assets/6a43dc36-12d7-4ee7-a57f-79cf11c209bc" />
