### PR TITLE
Implement generation of texture coordinates for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -34,7 +34,7 @@
 
 // 0x3b4,0x3d4
 #define VGA_CRTC_MAX 0x18
-#define GEFORCE_CRTC_MAX 0x9F
+#define GEFORCE_CRTC_MAX 0xF0
 
 #define GEFORCE_CHANNEL_COUNT 32
 #define GEFORCE_SUBCHANNEL_COUNT 8
@@ -209,8 +209,12 @@ struct gf_channel
   Bit32u d3d_cull_face;
   Bit32u d3d_front_face;
   Bit32u d3d_light_enable_mask;
+  Bit32u d3d_texgen[8][4];
+  Bit32u d3d_texture_matrix_enable[16];
+  float d3d_model_view_matrix[16];
   float d3d_inverse_model_view_matrix[12];
   float d3d_composite_matrix[16];
+  float d3d_texture_matrix[8][16];
   Bit32u d3d_scissor_x;
   Bit32u d3d_scissor_width;
   Bit32u d3d_scissor_y;
@@ -515,6 +519,7 @@ private:
   Bit32u crtc_intr_en;
   Bit32u crtc_start;
   Bit32u crtc_config;
+  Bit32u crtc_raster_pos;
   Bit32u crtc_cursor_offset;
   Bit32u crtc_cursor_config;
   Bit32u ramdac_cu_start_pos;


### PR DESCRIPTION
This change allows lens effect from [BumpLens](https://github.com/user-attachments/files/22571416/BumpLens.zip) program to work correctly with NV35 and 81.98 driver.
Additionally, this change:
* Fixes crash during boot of Windows 9x with NV20 in 640x480 mode;
* Implements vertex shader operations `SEQ`, `SFL`, `SGT`, `SLE`, `SNE` and `STR`;
* Fixes hang of Ballance game.
<img width="650" height="564" alt="Screenshot_2025-10-28_13-29-46" src="https://github.com/user-attachments/assets/75b19736-5a9a-4036-a218-45aef1bcc889" />
