### PR TITLE
Add basic register combiners support for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -187,6 +187,8 @@ struct gf_channel
   Bit16s d3d_window_offset_y;
   Bit32u d3d_surface_color_offset;
   Bit32u d3d_surface_zeta_offset;
+  Bit32u d3d_combiner_alpha_icw[8];
+  Bit32u d3d_combiner_final[2];
   Bit32u d3d_alpha_test_enable;
   Bit32u d3d_alpha_func;
   Bit32u d3d_alpha_ref;
@@ -226,6 +228,8 @@ struct gf_channel
   Bit32u d3d_viewport_horizontal;
   Bit32u d3d_viewport_vertical;
   float d3d_viewport_offset[4];
+  Bit32u d3d_combiner_alpha_ocw[8];
+  Bit32u d3d_combiner_color_icw[8];
   float d3d_viewport_scale[4];
   Bit32u d3d_transform_program[544][4];
   float d3d_transform_constant[512][4];
@@ -263,6 +267,9 @@ struct gf_channel
   Bit32u d3d_zstencil_clear_value;
   Bit32u d3d_color_clear_value;
   Bit32u d3d_clear_surface;
+  Bit32u d3d_combiner_color_ocw[8];
+  Bit32u d3d_combiner_control;
+  Bit32u d3d_combiner_control_num_stages;
   Bit32u d3d_transform_execution_mode;
   Bit32u d3d_transform_program_load;
   Bit32u d3d_transform_program_start;
@@ -454,6 +461,7 @@ private:
   BX_GEFORCE_SMF void d3d_sample_texture(gf_channel* ch,
     Bit32u tex_unit, float str[3], float color[4]);
   BX_GEFORCE_SMF void d3d_vertex_shader(gf_channel* ch, float in[16][4], float out[16][4]);
+  BX_GEFORCE_SMF void d3d_register_combiners(gf_channel* ch, float ps_in[16][4], float out[4]);
   BX_GEFORCE_SMF void d3d_pixel_shader(gf_channel* ch, float in[16][4], float tmp_regs16[64][4], float tmp_regs32[64][4]);
   BX_GEFORCE_SMF void d3d_triangle(gf_channel* ch, Bit32u base);
   BX_GEFORCE_SMF void d3d_triangle_clipped(gf_channel* ch, float v0[16][4], float v1[16][4], float v2[16][4]);


### PR DESCRIPTION
This change allows Frogger 2 to look better with NV20 (#641). Also it partially fixes rendering of Ubuntu 12 UI with NV35.
<img width="650" height="564" alt="Screenshot_2025-11-02_21-48-22" src="https://github.com/user-attachments/assets/c0c2c9c8-2d9d-40a0-b284-f0d8ea360880" />
<img width="810" height="684" alt="Screenshot_2025-11-02_22-32-30" src="https://github.com/user-attachments/assets/ae327acd-1b46-445b-915b-8b6a3dc48e0e" />