### PR TITLE
Add basic support for NV15_3D class

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -42,6 +42,27 @@
 
 #define BX_ROP_PATTERN 0x01
 
+struct gf_texture
+{
+  Bit32u offset;
+  Bit32u dma_obj;
+  Bit32u format;
+  bool linear;
+  bool unnormalized;
+  Bit32u color_bytes;
+  Bit32u base_size[3];
+  Bit32u wrap[3];
+  Bit32u control0;
+  bool enabled;
+  Bit32u control1;
+  Bit32u filter;
+  Bit32u image_rect;
+  Bit32u pal_dma_obj;
+  Bit32u pal_ofs;
+  Bit32u control3;
+  Bit32u key_color;
+};
+
 struct gf_channel
 {
   Bit32u subr_return;
@@ -252,16 +273,7 @@ struct gf_channel
   float d3d_vertex_data[4][16][4];
   Bit32u d3d_index_array_offset;
   Bit32u d3d_index_array_dma;
-  Bit32u d3d_texture_offset[16];
-  Bit32u d3d_texture_format[16];
-  Bit32u d3d_texture_address[16];
-  Bit32u d3d_texture_control0[16];
-  Bit32u d3d_texture_control1[16];
-  Bit32u d3d_texture_filter[16];
-  Bit32u d3d_texture_image_rect[16];
-  Bit32u d3d_texture_palette[16];
-  Bit32u d3d_texture_control3[16];
-  Bit32u d3d_texture_key_color[16];
+  gf_texture d3d_texture[16];
   Bit32u d3d_semaphore_obj;
   Bit32u d3d_semaphore_offset;
   Bit32u d3d_zstencil_clear_value;
@@ -459,7 +471,7 @@ private:
   BX_GEFORCE_SMF bool d3d_scissor_clip(gf_channel* ch, Bit32u* x, Bit32u* y, Bit32u* width, Bit32u* height);
   BX_GEFORCE_SMF void d3d_clear_surface(gf_channel* ch);
   BX_GEFORCE_SMF void d3d_sample_texture(gf_channel* ch,
-    Bit32u tex_unit, float str[3], float color[4]);
+    gf_texture* tex, float str[3], float color[4]);
   BX_GEFORCE_SMF void d3d_vertex_shader(gf_channel* ch, float in[16][4], float out[16][4]);
   BX_GEFORCE_SMF void d3d_register_combiners(gf_channel* ch, float ps_in[16][4], float out[4]);
   BX_GEFORCE_SMF void d3d_pixel_shader(gf_channel* ch, float in[16][4], float tmp_regs16[64][4], float tmp_regs32[64][4]);


### PR DESCRIPTION
This change allows text to be visible in Ubuntu 12.04.5 with NV20 card.
Also it is possible now to boot NV15 card directly (with [Leadtek.2Pro.64.010403_AGP.bin.zip](https://github.com/user-attachments/files/23430272/Leadtek.2Pro.64.010403_AGP.bin.zip) BIOS), but there are not many features implemented for it yet.
<img width="810" height="684" alt="Screenshot_2025-11-08_08-02-54" src="https://github.com/user-attachments/assets/ac946d3e-33dd-4a43-92f7-d2c7add5ca5f" />
