### PR TITLE
Improve text rendering in Linux with NV20

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -55,7 +55,8 @@ struct gf_texture
   Bit32u control0;
   bool enabled;
   Bit32u control1;
-  Bit32u filter;
+  bool signed_any;
+  bool signed_comp[4];
   Bit32u image_rect;
   Bit32u pal_dma_obj;
   Bit32u pal_ofs;
@@ -234,7 +235,8 @@ struct gf_channel
   Bit32u d3d_light_enable_mask;
   Bit32u d3d_texgen[8][4];
   Bit32u d3d_texture_matrix_enable[16];
-  float d3d_model_view_matrix[16];
+  Bit32u d3d_view_matrix_enable;
+  float d3d_model_view_matrix[2][16];
   float d3d_inverse_model_view_matrix[12];
   float d3d_composite_matrix[16];
   float d3d_texture_matrix[8][16];
@@ -286,9 +288,11 @@ struct gf_channel
   Bit32u d3d_transform_program_load;
   Bit32u d3d_transform_program_start;
   Bit32u d3d_transform_constant_load;
-  Bit32u d3d_attrib_color;
-  Bit32u d3d_dci;
-  Bit32u d3d_attrib_tex_coord[10];
+  Bit32u d3d_attrib_in_normal;
+  Bit32u d3d_attrib_in_color[2];
+  Bit32u d3d_attrib_out_color[2];
+  Bit32u d3d_attrib_in_tex_coord[16];
+  Bit32u d3d_attrib_out_tex_coord[16];
   Bit32u d3d_tex_coord_count;
 
   Bit8u  rop;


### PR DESCRIPTION
With this change, text rendering in Linux with NV20 is almost fixed.
It is possible to get correct result with Ubuntu 12.04.5 and openSUSE 13.2 IceWM, but it is not stable yet.
Also this change implements support for vertex buffers with NV15.

<img width="810" height="684" alt="Screenshot_2025-11-09_20-14-19" src="https://github.com/user-attachments/assets/facb9307-b7c3-4947-93e1-40f43ab84b6f" />
<img width="650" height="564" alt="Screenshot_2025-11-09_19-43-05" src="https://github.com/user-attachments/assets/ba2fdaa3-ab31-4fd9-96e6-e15070df5979" />
