### PR TITLE
Implement software interrupts for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -506,6 +506,7 @@ private:
     Bit8u reg[GEFORCE_CRTC_MAX+1];
   } crtc; // 0x3b4-5/0x3d4-5
 
+  bool mc_soft_intr;
   Bit32u mc_intr_en;
   Bit32u mc_enable;
   Bit32u bus_intr;


### PR DESCRIPTION
This change fixes loading of Kororaa Linux with NV40 (#670).

<img width="1034" height="852" alt="Screenshot_2025-11-19_10-09-15" src="https://github.com/user-attachments/assets/68c1f958-0161-4015-99d4-86be918da34f" />
