### PR TITLE
Fix texture loading in Teeworlds with NV35

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -168,6 +168,7 @@ struct gf_channel
 
   Bit32u sifm_src;
   bool sifm_swizzled;
+  bool sifm_swizzled_0389;
   Bit32u sifm_operation;
   Bit32u sifm_color_fmt;
   Bit32u sifm_color_bytes;
@@ -467,7 +468,7 @@ private:
   BX_GEFORCE_SMF void execute_sifc(gf_channel* ch, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_beta(gf_channel* ch, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_tfc(gf_channel* ch, Bit32u method, Bit32u param);
-  BX_GEFORCE_SMF void execute_sifm(gf_channel* ch, Bit32u method, Bit32u param);
+  BX_GEFORCE_SMF void execute_sifm(gf_channel* ch, Bit32u cls, Bit32u method, Bit32u param);
   BX_GEFORCE_SMF void execute_d3d(gf_channel* ch, Bit32u cls, Bit32u method, Bit32u param);
 
   BX_GEFORCE_SMF Bit32u get_pixel(Bit32u obj, Bit32u ofs, Bit32u x, Bit32u cb);
@@ -485,7 +486,7 @@ private:
   BX_GEFORCE_SMF void copyarea(gf_channel* ch);
   BX_GEFORCE_SMF void tfc(gf_channel* ch);
   BX_GEFORCE_SMF void m2mf(gf_channel* ch);
-  BX_GEFORCE_SMF void sifm(gf_channel* ch);
+  BX_GEFORCE_SMF void sifm(gf_channel* ch, bool swizzled);
 
   BX_GEFORCE_SMF bool d3d_scissor_clip(gf_channel* ch, Bit32u* x, Bit32u* y, Bit32u* width, Bit32u* height);
   BX_GEFORCE_SMF void d3d_clear_surface(gf_channel* ch);


### PR DESCRIPTION
This change fixes texture loading in Teeworlds 0.4.3 with Windows 2000, 93.71 driver and NV35 card. Because in such case both `NV30_SIFM` (`0x0389`) and `NV10_SIFM` (`0x0089`) classes are used in the same channel, it is not enough to have single memory location for swizzled flag.
Also this change fixes operation of Z clearing algorithm used by OpenGL driver in full screen mode with NV20 card. Differences can be observed, for example, with NeHe lessons 2 and 5.

<img width="650" height="564" alt="Screenshot_2025-11-25_22-24-38" src="https://github.com/user-attachments/assets/12f342ee-6681-4ce6-b830-4176658313a9" />
