### PR TITLE
Implement stencil testing for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -233,8 +233,17 @@ struct gf_channel
   Bit32u d3d_cull_face_enable;
   Bit32u d3d_depth_test_enable;
   Bit32u d3d_depth_write_enable;
+  Bit32u d3d_stencil_mask;
+  Bit32u d3d_stencil_func;
+  Bit32u d3d_stencil_func_ref;
+  Bit32u d3d_stencil_func_mask;
+  Bit32u d3d_stencil_op_sfail;
+  Bit32u d3d_stencil_op_dpfail;
+  Bit32u d3d_stencil_op_dppass;
   Bit32u d3d_lighting_enable;
+  Bit32u d3d_stencil_test_enable;
   Bit32u d3d_depth_func;
+  Bit32u d3d_color_mask;
   Bit32u d3d_shade_mode;
   float d3d_clip_min;
   float d3d_clip_max;


### PR DESCRIPTION
This change allows shadows to appear in Toy Soldiers demo with 45.23 driver and NV35.
Additionally, this change fixes rendering of Doom 3 menu with 93.71 driver and NV20 (#694).

<img width="650" height="564" alt="Screenshot_2025-12-19_13-24-16" src="https://github.com/user-attachments/assets/e7e134f2-48e4-4c00-884c-c6bdab05ff1d" />
<img width="650" height="564" alt="Screenshot_2025-12-19_14-16-23" src="https://github.com/user-attachments/assets/e4734079-e62d-4588-a459-e2030d3124a3" />
