### PR TITLE
Add initialization of vertex shader temporary registers with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -319,6 +319,7 @@ struct gf_channel
   Bit32u d3d_attrib_out_color[2];
   Bit32u d3d_attrib_in_tex_coord[16];
   Bit32u d3d_attrib_out_tex_coord[16];
+  Bit32u d3d_vs_temp_regs_count;
   Bit32u d3d_tex_coord_count;
 
   Bit8u  rop;


### PR DESCRIPTION
This change fixes colors of shiny objects in Adventure test of 3DMark2000 with 81.98 driver and NV40.
<img width="650" height="564" alt="Screenshot_2025-12-22_09-45-10" src="https://github.com/user-attachments/assets/53948de2-f009-4263-8a98-800fcf446c3c" />
