### PR TITLE
Implement texture value expansion for GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -633,6 +633,7 @@ private:
 
   Bit8u *disp_ptr;
   Bit32u disp_offset;
+  Bit32u disp_end_offset;
   Bit32u bank_base[2];
 
   struct {


### PR DESCRIPTION
This change allows balls from [DotProduct3](https://github.com/user-attachments/files/24373565/DotProduct3.zip) example to be shaded correctly with 81.98 driver and NV40.
Additionally, it:
* Optimizes memory writes for off-screen rendering cases;
* Fixes activation of stencil test for NV35 (#699).
<img width="650" height="564" alt="Screenshot_2025-12-29_21-51-51" src="https://github.com/user-attachments/assets/724aafc4-6864-4ae3-8c99-e18547327dd0" />
