### PR TITLE
Fix multitasking with GeForce

### DIFF
--- a/bochs/iodev/display/geforce.h
+++ b/bochs/iodev/display/geforce.h
@@ -469,6 +469,7 @@ private:
 
   BX_GEFORCE_SMF void ramht_lookup(Bit32u handle, Bit32u chid, Bit32u* object, Bit8u* engine);
 
+  BX_GEFORCE_SMF void update_fifo_wait();
   BX_GEFORCE_SMF void fifo_process();
   BX_GEFORCE_SMF void fifo_process(Bit32u chid);
   BX_GEFORCE_SMF int execute_command(Bit32u chid, Bit32u subc, Bit32u method, Bit32u param);
@@ -542,6 +543,7 @@ private:
   Bit32u bus_intr_en;
   bool fifo_wait;
   bool fifo_wait_soft;
+  bool fifo_wait_notify;
   bool fifo_wait_flip;
   bool fifo_wait_acquire;
   Bit32u fifo_intr;
@@ -550,6 +552,7 @@ private:
   Bit32u fifo_ramfc;
   Bit32u fifo_ramro;
   Bit32u fifo_mode;
+  Bit32u fifo_cache1_push0;
   Bit32u fifo_cache1_push1;
   Bit32u fifo_cache1_put;
   Bit32u fifo_cache1_dma_push;


### PR DESCRIPTION
This change allows several `glxgears` processes to run simultaneously with 81.98 driver and NV40.

<img width="650" height="564" alt="Screenshot_2026-01-02_09-28-04" src="https://github.com/user-attachments/assets/cffad1ae-2fb6-44dd-9396-caf0aec54fbd" />
