### PR TITLE
config: fix potential null pointer dereference in bx_init_options()

### DIFF
--- a/bochs/config.cc
+++ b/bochs/config.cc
@@ -519,7 +519,7 @@ void bx_init_options()
   bx_param_bool_c *enabled, *readonly;
   bx_param_enum_c *mode, *type, *toggle, *status;
   bx_param_filename_c *path;
-  char name[BX_PATHNAME_LEN], descr[512], label[512];
+  char name[BX_PATHNAME_LEN], descr[512], label[512], bxshare[BX_PATHNAME_LEN];
 
   bx_param_c *root_param = SIM->get_param(".");
 
@@ -746,7 +746,8 @@ void bx_init_options()
       "Pathname of ROM image to load",
       "", BX_PATHNAME_LEN);
   path->set_format("Name of ROM BIOS image: %s");
-  sprintf(name, "%s" DIRECTORY_SEPARATOR "BIOS-bochs-latest", (char *)get_builtin_variable("BXSHARE"));
+  get_bxshare_path(bxshare);
+  sprintf(name, "%s" DIRECTORY_SEPARATOR "BIOS-bochs-latest", bxshare);
   path->set_initial_val(name);
   bx_param_num_c *romaddr = new bx_param_num_c(rom,
       "address",
@@ -775,7 +776,7 @@ void bx_init_options()
       "Pathname of VGA ROM image to load",
       "", BX_PATHNAME_LEN);
   path->set_format("Name of VGA BIOS image: %s");
-  sprintf(name, "%s" DIRECTORY_SEPARATOR "VGABIOS-lgpl-latest.bin", get_builtin_variable("BXSHARE"));
+  sprintf(name, "%s" DIRECTORY_SEPARATOR "VGABIOS-lgpl-latest.bin", bxshare);
   path->set_initial_val(name);
   vgarom->set_options(vgarom->SERIES_ASK);
 


### PR DESCRIPTION
get_builtin_variable() can return NULL on Windows if the registry key is not found. Using the return value directly in sprintf() causes undefined behavior.

Use get_bxshare_path() instead, which properly handles the NULL case with a fallback to current directory.