### PR TITLE
Round adaptive block size to the next highest power of 2

### DIFF
--- a/bochs/main.cc
+++ b/bochs/main.cc
@@ -105,6 +105,17 @@ BOCHSAPI BX_MEM_C bx_mem;
 
 char *bochsrc_filename = NULL;
 
+Bit32u round_up_to_power_of_2(Bit32u x)
+{
+  Bit32u r = x - 1;
+  r |= r >> 1;
+  r |= r >> 2;
+  r |= r >> 4;
+  r |= r >> 8;
+  r |= r >> 16;
+  return r + 1;
+}
+
 size_t bx_get_timestamp(char *buffer)
 {
 #if VER_DEVFLAG == 1
@@ -1311,6 +1322,7 @@ void bx_init_hardware()
   if (memBlockSize < 4096) {
     memBlockSize = memSize / 4096;
     if (memBlockSize < 4096) memBlockSize = 4096;
+    memBlockSize = round_up_to_power_of_2(memBlockSize);
     BX_INFO(("Auto-adjusting memory block size to %u", memBlockSize));
   }
 


### PR DESCRIPTION
This change fixes `[MEM0  ] Block size 4352 is not power of two !`  crash when using `memory: guest=17, host=17` configuration.