### PR TITLE
Fix VMX on UEFI

### DIFF
--- a/bochs/cpu/cpu.h
+++ b/bochs/cpu/cpu.h
@@ -4852,6 +4852,7 @@ public: // for now...
 #endif
 
   BX_SMF void reset(unsigned source);
+  BX_SMF void allowVmxForFirmware(void);
   BX_SMF void shutdown(void);
   BX_SMF void enter_sleep_state(unsigned state);
   BX_SMF void handleCpuModeChange(void);

--- a/bochs/cpu/cpu.h
+++ b/bochs/cpu/cpu.h
@@ -4852,7 +4852,6 @@ public: // for now...
 #endif
 
   BX_SMF void reset(unsigned source);
-  BX_SMF void allowVmxForFirmware(void);
   BX_SMF void shutdown(void);
   BX_SMF void enter_sleep_state(unsigned state);
   BX_SMF void handleCpuModeChange(void);
@@ -5395,6 +5394,7 @@ public: // for now...
   BX_SMF void VMexit_CR8_Read(bxInstruction_c *i) BX_CPP_AttrRegparmN(1);
   BX_SMF void VMexit_CR8_Write(bxInstruction_c *i) BX_CPP_AttrRegparmN(1);
   BX_SMF void VMexit_DR_Access(unsigned read, unsigned dr, unsigned reg);
+  BX_SMF void allowVmxForFirmware(void);
 #if BX_SUPPORT_VMX >= 2
   BX_SMF void Virtualization_Exception(Bit64u qualification, Bit64u guest_physical, Bit64u guest_linear);
   BX_SMF void vmfunc_eptp_switching(void);

--- a/bochs/cpu/init.cc
+++ b/bochs/cpu/init.cc
@@ -1307,6 +1307,24 @@ void BX_CPU_C::reset(unsigned source)
   BX_INSTR_RESET(BX_CPU_ID, source);
 }
 
+void BX_CPU_C::allowVmxForFirmware(void)
+{
+#if BX_SUPPORT_VMX
+  // The Bochs BIOS enables VMX in IA32_FEATURE_CONTROL itself. External
+  // firmware uses the fw_cfg path and needs the same setup from the emulator.
+  if (! is_cpu_extension_supported(BX_ISA_VMX)) {
+    return;
+  }
+
+  const Bit32u required_bits = BX_IA32_FEATURE_CONTROL_BITS;
+  if ((BX_CPU_THIS_PTR msr.ia32_feature_ctrl & required_bits) == required_bits) {
+    return;
+  }
+
+  BX_CPU_THIS_PTR msr.ia32_feature_ctrl |= required_bits;
+#endif
+}
+
 void BX_CPU_C::sanity_checks(void)
 {
   Bit32u eax = EAX, ecx = ECX, edx = EDX, ebx = EBX, esp = ESP, ebp = EBP, esi = ESI, edi = EDI;

--- a/bochs/cpu/init.cc
+++ b/bochs/cpu/init.cc
@@ -1307,23 +1307,18 @@ void BX_CPU_C::reset(unsigned source)
   BX_INSTR_RESET(BX_CPU_ID, source);
 }
 
+#if BX_SUPPORT_VMX
 void BX_CPU_C::allowVmxForFirmware(void)
 {
-#if BX_SUPPORT_VMX
   // The Bochs BIOS enables VMX in IA32_FEATURE_CONTROL itself. External
   // firmware uses the fw_cfg path and needs the same setup from the emulator.
   if (! is_cpu_extension_supported(BX_ISA_VMX)) {
     return;
   }
 
-  const Bit32u required_bits = BX_IA32_FEATURE_CONTROL_BITS;
-  if ((BX_CPU_THIS_PTR msr.ia32_feature_ctrl & required_bits) == required_bits) {
-    return;
-  }
-
-  BX_CPU_THIS_PTR msr.ia32_feature_ctrl |= required_bits;
-#endif
+  BX_CPU_THIS_PTR msr.ia32_feature_ctrl |= BX_IA32_FEATURE_CONTROL_BITS;
 }
+#endif
 
 void BX_CPU_C::sanity_checks(void)
 {

--- a/bochs/iodev/fw_cfg.cc
+++ b/bochs/iodev/fw_cfg.cc
@@ -24,9 +24,10 @@
 
 #define BX_PLUGGABLE
 
-#define NEED_CPU_REG_SHORTCUTS 1
 #include "iodev.h"
+#if BX_SUPPORT_VMX
 #include "cpu/cpu.h"
+#endif
 #include "fw_cfg.h"
 #include "acpi_tables.h"
 
@@ -236,11 +237,11 @@ void bx_fw_cfg_c::reset(unsigned type)
 
   // The Bochs BIOS enables VMX on its own. External firmware uses fw_cfg,
   // whose reset callback runs after CPU reset, so allow VMX here first.
-  if (SIM->get_param_bool(BXPN_FW_CFG_ENABLED)->get()) {
-    for (unsigned cpu = 0; cpu < BX_SMP_PROCESSORS; cpu++) {
-      BX_CPU(cpu)->allowVmxForFirmware();
-    }
+#if BX_SUPPORT_VMX
+  for (unsigned cpu = 0; cpu < BX_SMP_PROCESSORS; cpu++) {
+    BX_CPU(cpu)->allowVmxForFirmware();
   }
+#endif
 
   first_reset = false;
 }

--- a/bochs/iodev/fw_cfg.cc
+++ b/bochs/iodev/fw_cfg.cc
@@ -26,6 +26,7 @@
 
 #define NEED_CPU_REG_SHORTCUTS 1
 #include "iodev.h"
+#include "cpu/cpu.h"
 #include "fw_cfg.h"
 #include "acpi_tables.h"
 
@@ -232,6 +233,15 @@ void bx_fw_cfg_c::reset(unsigned type)
   cur_entry = FW_CFG_INVALID;
   cur_offset = 0;
   dma_addr = 0;
+
+  // The Bochs BIOS enables VMX on its own. External firmware uses fw_cfg,
+  // whose reset callback runs after CPU reset, so allow VMX here first.
+  if (SIM->get_param_bool(BXPN_FW_CFG_ENABLED)->get()) {
+    for (unsigned cpu = 0; cpu < BX_SMP_PROCESSORS; cpu++) {
+      BX_CPU(cpu)->allowVmxForFirmware();
+    }
+  }
+
   first_reset = false;
 }
 


### PR DESCRIPTION
This fixes Intel VMX initialization when booting through OVMF.

Bochs BIOS enables VMX in IA32_FEATURE_CONTROL itself, but the UEFI/fw_cfg path does not. As a result, guests that rely on VMX can fail under UEFI even though the same setup works with the Bochs BIOS.

This change adds a small CPU helper that ensures the required IA32_FEATURE_CONTROL bits are present and calls it from the fw_cfg reset path before external firmware runs.

What this changes:
- sets the required bits when VMX is enabled
- limits the workaround to the external firmware path (UEFI), where the missing initialization occurs

With this change, VMX is properly recognized and used e.g. by Hyper-V. Without the change, VMX is unused. 