### PR TITLE
sb16: fix OPL timer mask check missing bit isolation

### DIFF
--- a/bochs/iodev/sound/sb16.cc
+++ b/bochs/iodev/sound/sb16.cc
@@ -2358,7 +2358,7 @@ void bx_sb16_c::opl_timerevent()
       }
       if (((++OPL.timer[i]) & mask) == 0) { // overflow occurred, set flags accordingly
         OPL.timer[i] = OPL.timerinit[i];      // reset the counter
-        if ((OPL.tmask[i/2] >> (6 - (i % 2))) == 0) { // set flags only if unmasked
+        if ((OPL.tmask[i/2] & (1 << (6 - (i % 2)))) == 0) { // set flags only if unmasked
           writelog(MIDILOG(5), "OPL Timer Interrupt: Chip %d, Timer %d", i/2, 1 << (i % 2));
           OPL.tflag[i/2] |= 1 << (6 - (i % 2));   // set the overflow flag
           OPL.tflag[i/2] |= 1 << 7;             // set the IRQ flag


### PR DESCRIPTION
The mask check in `opl_timerevent()` uses `>> (6 - (i % 2))` without masking off the higher bits.  When checking timer 2's mask (i=1, shifts right by 5), the result also includes bit 6 (timer 1's mask), so setting `T1MSK` incorrectly suppresses timer 2's status flag even when `T2MSK` is clear.

The T1 path (i=0) accidentally works because shifting a byte right by 6 leaves only bit 6 surviving in the low bits.  The T2 path is where the bug shows.

The start-bit check three lines above already uses `& (1 << ...)` isolation; this patch applies the same pattern to the mask check.

### Reference

- **YMF262 datasheet**: reg `0x04` bit 6 = `T1MSK`, bit 5 = `T2MSK` — two independent IRQ-mask bits.
- **MAME's `ymf262.cpp`**: `OPL3_STATUSMASK_SET(chip, (~v) & 0x60)` followed by per-bit `chip->status |= flag & chip->statusmask` — i.e. isolated per-timer masking.

### Verification

I observed this while writing a small DOS test that programs both OPL timers and exercises mask combinations.  Starting `T1` (reload `0xFE`, 160 µs period) + `T2` (reload `0xFE`, 640 µs period) and then writing different mask combinations to reg `0x04`:

  | reg 0x04 | meaning | spec | current Bochs | with patch |
  |---|---|---|---|---|

Practical impact on real software is probably small — I don't know of games that rely on `T1`-mask + `T2`-unmask + simultaneous polling — but the spec deviation is straightforward to fix.