### PR TITLE
Attempt to implement #FERR and #IGNNE handling as well as MSDOS compatibility mode of handling x87 unmasked exceptions

### DIFF
--- a/bochs/CHANGES
+++ b/bochs/CHANGES
@@ -2,6 +2,7 @@ Changes in 3.1 (coming soon):
 
 Brief summary :
   - CPU: Implemented FRED, USER_MSR, MOVRS, AMX-FP8 ISA extensions emulation
+  - CPU: Implemented MS-DOS Compatibility mode for handling x87 FPU exceptions, FERR# and IGNNE# pins enabled when 'extfpuirq' plugin is enabled
   - CPUDB: Added new Wildcat Lake CPU definition featuring FRED, WRMSRNS and MSRLIST
   - Bugfixes for CPU emulation correctness
     (critical bugfixes for emulation of XSAVEC/XSAVES, PKeys, AVX BMI1/BMI2, AVX512, AMX, UINTR, CET and SVM)
@@ -23,12 +24,13 @@ Detailed change log :
     In the code BX_WARN is used and it is configurable like other log levels.
 
 - CPU emulation and instrumentation
-  - CPU: Implemented AMX-FP8 ISA extension
-  - CPU: Implemented MOVRS ISA support: MOVRS, AVX10.2 MOVRS, AMX MOVRS
-  - CPU: implemented IA32_APERF (0xe7) and IA32_MPERF (0xe8) MSRs
-  - CPU: implemented Flexible Return and Delivery (FRED) architecture emulation
-  - CPU: implemented USER_MSR extensions emulation (URDMSR/UWRMSR)
+  - Implemented AMX-FP8 ISA extension
+  - Implemented MOVRS ISA support: MOVRS, AVX10.2 MOVRS, AMX MOVRS
+  - Implemented IA32_APERF (0xe7) and IA32_MPERF (0xe8) MSRs
+  - Implemented Flexible Return and Delivery (FRED) architecture emulation
+  - Implemented USER_MSR extensions emulation (URDMSR/UWRMSR)
   - CPUDB: Added new Wildcat Lake CPU definition featuring FRED, WRMSRNS and MSRLIST
+  - Implemented MS-DOS Compatibility mode for handling x87 FPU exceptions, FERR# and IGNNE# pins enabled when 'extfpuirq' plugin is enabled
   - Bugfixes for CPU emulation correctness (critical bugfixes for emulation of XSAVEC/XSAVES, PKeys, AVX BMI1/BMI2, AVX512, AMX, UINTR, CET and SVM)
   - Updated instrumentation callbacks, see description in instrumentation.txt
     - Added new BX_INSTR_CPUID instrumentation callback, branch callbacks simplified

--- a/bochs/cpu/HISTORY
+++ b/bochs/cpu/HISTORY
@@ -79,6 +79,7 @@ Changes in Bochs 3.1 (coming soon):
 - x87: correctly handle preudo-denormal zero in FRNDINT instruction
 - VMX: fix VMX guest activity state reported on VMEXIT occured during HLT (should be BX_ACTIVITY_STATE_HLT=1)
 + CPUID: Update Arrow Lake CPUID - enable missing leaf CPUID leaf=7.subleaf=1[EDX]
+- x87: Implemented MS-DOS Compatibility mode for handling x87 FPU exceptions, FERR# and IGNNE# pins enabled when 'extfpuirq' plugin is enabled
 
 -------------------------------------------------------------------------
 Changes in Bochs 3.0 (February 16, 2025)

--- a/bochs/cpu/cpu.h
+++ b/bochs/cpu/cpu.h
@@ -1201,6 +1201,7 @@ public: // for now...
     BX_ACTIVITY_STATE_SHUTDOWN,
     BX_ACTIVITY_STATE_WAIT_FOR_SIPI,
     BX_VMX_LAST_ACTIVITY_STATE = BX_ACTIVITY_STATE_WAIT_FOR_SIPI,
+    BX_ACTIVITY_WAIT_FOR_X87,
     BX_ACTIVITY_STATE_MWAIT,
     BX_ACTIVITY_STATE_MWAIT_IF
   };
@@ -5047,6 +5048,9 @@ public: // for now...
   BX_SMF void    deliver_NMI(void);
   BX_SMF void    deliver_SMI(void);
   BX_SMF void    deliver_SIPI(unsigned vector);
+
+  BX_SMF bool    get_IGNNE();
+
 #if BX_SUPPORT_UINTR
   BX_SMF void    deliver_UINTR();
   BX_SMF void    Process_UINTR_Notification();
@@ -5189,11 +5193,12 @@ public: // for now...
 #if BX_SUPPORT_FPU
   BX_SMF void print_state_FPU(void);
   BX_SMF void FPU_check_pending_exceptions(void);
-  BX_SMF void FPU_ignore_numeric_exception(bool val);
   BX_SMF void FPU_update_last_instruction(bxInstruction_c *i);
   BX_SMF void FPU_stack_underflow(bxInstruction_c *i, int stnr, int pop_stack = 0);
   BX_SMF void FPU_stack_overflow(bxInstruction_c *i);
   BX_SMF unsigned FPU_exception(bxInstruction_c *i, unsigned exception, bool = 0);
+  BX_SMF void set_unmasked_fpu_exception();
+  BX_SMF void clear_unmasked_fpu_exception();
   BX_SMF bx_address fpu_save_environment(bxInstruction_c *i);
   BX_SMF bx_address fpu_load_environment(bxInstruction_c *i);
   BX_SMF Bit8u pack_FPU_TW(Bit16u tag_word);

--- a/bochs/cpu/event.cc
+++ b/bochs/cpu/event.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//   Copyright (c) 2011-2025 Stanislav Shwartsman
+//   Copyright (c) 2011-2026 Stanislav Shwartsman
 //          Written by Stanislav Shwartsman [sshwarts at sourceforge net]
 //
 //  This library is free software; you can redistribute it and/or
@@ -69,6 +69,11 @@ bool BX_CPU_C::handleWaitForEvent(void)
       break;
     }
 
+    if (BX_CPU_THIS_PTR activity_state == BX_ACTIVITY_WAIT_FOR_X87 && BX_CPU_THIS_PTR get_IGNNE()) {
+      // #IGNNE is raised, end of waiting
+      break;
+    }
+
     if (is_unmasked_event_pending(BX_EVENT_VMX_PREEMPTION_TIMER_EXPIRED)) {
       // Exit from waiting loop and proceed to VMEXIT
       break;
@@ -110,6 +115,10 @@ bool BX_CPU_C::handleWaitForEvent(void)
 
     BX_TICKN(10); // when in HLT run time faster for single CPU
   }
+
+  // wakeup if were waiting for x87
+  if (BX_CPU_THIS_PTR activity_state == BX_ACTIVITY_WAIT_FOR_X87)
+    BX_CPU_THIS_PTR activity_state = BX_ACTIVITY_STATE_ACTIVE;
 
   return 0;
 }
@@ -468,6 +477,11 @@ void BX_CPU_C::inhibit_interrupts(unsigned mask)
 bool BX_CPU_C::interrupts_inhibited(unsigned mask)
 {
   return (get_icount() <= BX_CPU_THIS_PTR inhibit_icount) && (BX_CPU_THIS_PTR inhibit_mask & mask) == mask;
+}
+
+bool BX_CPU_C::get_IGNNE()
+{
+  return bx_pc_system.get_IGNNE();
 }
 
 void BX_CPU_C::deliver_SIPI(unsigned vector)

--- a/bochs/cpu/fpu/ferr.cc
+++ b/bochs/cpu/fpu/ferr.cc
@@ -178,6 +178,8 @@ unsigned BX_CPU_C::FPU_exception(bxInstruction_c *i, unsigned exception, bool is
 // Family Developer's Manual: Volume 1
 //
 
+#include "iodev/iodev.h"
+
 void BX_CPU_C::FPU_check_pending_exceptions(void)
 {
   if(BX_CPU_THIS_PTR the_i387.get_partial_status() & FPU_SW_Summary)
@@ -195,15 +197,15 @@ void BX_CPU_C::FPU_check_pending_exceptions(void)
      {
         // MSDOS compatibility mode
         if (! BX_CPU_THIS_PTR get_IGNNE()) {
-          // if "deferred" method of reporting the error is used here is the time to assert FERR#
+          // with "deferred" method of reporting the error here is the time to assert FERR#
+          DEV_extfpuirq_set_fpu_error(true);
+
           enter_sleep_state(BX_ACTIVITY_WAIT_FOR_X87);
           longjmp(BX_CPU_THIS_PTR jmp_buf_env, 1); // go back to main decode loop
         }
      }
   }
 }
-
-#include "iodev/iodev.h"
 
 // this code uses "immediate" method of reporting errors for simplicity
 void BX_CPU_C::set_unmasked_fpu_exception()

--- a/bochs/cpu/fpu/ferr.cc
+++ b/bochs/cpu/fpu/ferr.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//   Copyright (c) 2003-2017 Stanislav Shwartsman
+//   Copyright (c) 2003-2026 Stanislav Shwartsman
 //          Written by Stanislav Shwartsman [sshwarts at sourceforge net]
 //
 //  This library is free software; you can redistribute it and/or
@@ -68,7 +68,7 @@ unsigned BX_CPU_C::FPU_exception(bxInstruction_c *i, unsigned exception, bool is
 
   /* Set summary bits iff exception isn't masked */
   if (unmasked) {
-    FPU_PARTIAL_STATUS |= (FPU_SW_Summary | FPU_SW_Backward);
+    set_unmasked_fpu_exception();
 
     // when FOPCODE deprecation is set, FOPCODE is updated only when unmasked x87 exception occurs
     if (is_cpu_extension_supported(BX_ISA_FOPCODE_DEPRECATION))
@@ -141,6 +141,91 @@ unsigned BX_CPU_C::FPU_exception(bxInstruction_c *i, unsigned exception, bool is
   }
 
   return unmasked;
+}
+
+//
+// When MS-DOS compatibility mode is enabled for the Intel486 or Pentium processors (NE bit is set to 0) and the
+// IGNNE# input pin is de-asserted, the FERR# signal is generated as follows:
+//
+// 1. When an x87 FPU instruction causes an unmasked x87 FPU exception, the processor (in most cases) uses a
+//    "deferred" method of reporting the error. This means that the processor does not respond immediately, but
+//    rather freezes just before executing the next WAIT or x87 FPU instruction (except for "no-wait" instructions,
+//    which the x87 FPU executes regardless of an error condition).
+//
+// 2. When the processor freezes, it also asserts the FERR# output.
+//
+// 3. The frozen processor waits for an external interrupt, which must be supplied by external hardware in response
+//    to the FERR# assertion.
+//
+// 4. In MS-DOS compatibility systems, FERR# is fed to the IRQ13 input in the cascaded PIC. The PIC generates
+//    interrupt 75H, which then branches to interrupt 2, as described earlier in this appendix for systems using the
+//    Intel 286 and Intel 287 or Intel386 and Intel 387 processors.
+//
+// The deferred method of error reporting is used for all exceptions caused by the basic arithmetic instructions
+// (including FADD, FSUB, FMUL, FDIV, FSQRT, FCOM and FUCOM), for precision exceptions caused by all types of x87
+// FPU instructions, and for numeric underflow and overflow exceptions caused by all types of x87 FPU instructions
+// except stores to memory.
+//
+// Some x87 FPU instructions with some x87 FPU exceptions use an "immediate" method of reporting errors. Here,
+// the FERR# is asserted immediately, at the time that the exception occurs. The immediate method of error
+// reporting is used for x87 FPU stack fault, invalid operation and denormal exceptions caused by all transcendental
+// instructions, FSCALE, FXTRACT, FPREM and others, and all exceptions (except precision) when caused by x87 FPU
+// store instructions. Like deferred error reporting, immediate error reporting will cause the processor to freeze just
+// before executing the next WAIT or x87 FPU instruction if the error condition has not been cleared by that time.
+// Note that in general, whether deferred or immediate error reporting is used for an x87 FPU exception depends both
+// on which exception occurred and which instruction caused that exception. A complete specification of these cases,
+// which applies to both the Pentium and the Intel486 processors, is given in Section 5.1.21 in the Pentium Processor
+// Family Developer's Manual: Volume 1
+//
+
+void BX_CPU_C::FPU_check_pending_exceptions(void)
+{
+  if(BX_CPU_THIS_PTR the_i387.get_partial_status() & FPU_SW_Summary)
+  {
+     // NE=1 selects the native or internal mode, which generates #MF,
+     // which is an extension introduced with 80486.
+     // NE=0 selects the original (backward compatible) FPU error
+     // handling, which generates an IRQ 13 via the PIC chip.
+#if BX_CPU_LEVEL >= 4
+     if (BX_CPU_THIS_PTR cr0.get_NE() != 0) {
+         exception(BX_MF_EXCEPTION, 0);
+     }
+     else
+#endif
+     {
+        // MSDOS compatibility mode
+        if (! BX_CPU_THIS_PTR get_IGNNE()) {
+          // if "deferred" method of reporting the error is used here is the time to assert FERR#
+          enter_sleep_state(BX_ACTIVITY_WAIT_FOR_X87);
+          longjmp(BX_CPU_THIS_PTR jmp_buf_env, 1); // go back to main decode loop
+        }
+     }
+  }
+}
+
+#include "iodev/iodev.h"
+
+// this code uses "immediate" method of reporting errors for simplicity
+void BX_CPU_C::set_unmasked_fpu_exception()
+{
+  /* set the B and ES bits in the status-word */
+  FPU_PARTIAL_STATUS |= (FPU_SW_Summary | FPU_SW_Backward);
+
+  BX_DEBUG(("Set FERR# on unmasked x87 exception"));
+
+  // Here we set FERR# (Reset after FSW B/ES are cleared)
+  DEV_extfpuirq_set_fpu_error(true);
+}
+
+void BX_CPU_C::clear_unmasked_fpu_exception()
+{
+  /* clear the B and ES bits in the status-word */
+  FPU_PARTIAL_STATUS &= ~(FPU_SW_Summary | FPU_SW_Backward);
+
+  BX_DEBUG(("Clear FERR#"));
+
+  // Here we set FERR# (Reset after FSW B/ES are cleared)
+  DEV_extfpuirq_set_fpu_error(false);
 }
 
 #endif

--- a/bochs/cpu/fpu/fpu.cc
+++ b/bochs/cpu/fpu/fpu.cc
@@ -443,8 +443,6 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::FNSTENV(bxInstruction_c *i)
   fpu_save_environment(i);
   /* mask all floating point exceptions */
   FPU_CONTROL_WORD |= FPU_CW_Exceptions_Mask;
-  /* clear the B and ES bits in the status word */
-  FPU_PARTIAL_STATUS &= ~(FPU_SW_Backward|FPU_SW_Summary);
 
   clear_unmasked_fpu_exception();
 

--- a/bochs/cpu/fpu/fpu.cc
+++ b/bochs/cpu/fpu/fpu.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//   Copyright (c) 2003-2018 Stanislav Shwartsman
+//   Copyright (c) 2003-2026 Stanislav Shwartsman
 //          Written by Stanislav Shwartsman [sshwarts at sourceforge net]
 //
 //  This library is free software; you can redistribute it and/or
@@ -26,8 +26,6 @@
 #include "cpu/cpu.h"
 #define LOG_THIS BX_CPU_THIS_PTR
 
-#include "iodev/iodev.h"
-
 #include "softfloat3e/include/softfloat.h"
 
 #define CHECK_PENDING_EXCEPTIONS 1
@@ -49,35 +47,6 @@ void BX_CPU_C::FPU_update_last_instruction(bxInstruction_c *i)
       BX_CPU_THIS_PTR the_i387.fdp = RMAddr(i);
     }
   }
-}
-
-void BX_CPU_C::FPU_check_pending_exceptions(void)
-{
-  if(BX_CPU_THIS_PTR the_i387.get_partial_status() & FPU_SW_Summary)
-  {
-     // NE=1 selects the native or internal mode, which generates #MF,
-     // which is an extension introduced with 80486.
-     // NE=0 selects the original (backward compatible) FPU error
-     // handling, which generates an IRQ 13 via the PIC chip.
-#if BX_CPU_LEVEL >= 4
-     if (BX_CPU_THIS_PTR cr0.get_NE() != 0) {
-         exception(BX_MF_EXCEPTION, 0);
-     }
-     else
-#endif
-     {
-        // MSDOS compatibility external interrupt (IRQ13)
-        BX_INFO(("math_abort: MSDOS compatibility FPU exception"));
-        DEV_pic_raise_irq(13);
-        // Here we should set FERR# (Reset after FSW B/ES are cleared)
-//        DEV_extfpuirq_set_fpu_error(true);
-     }
-  }
-}
-
-void BX_CPU_C::FPU_ignore_numeric_exception(bool val)
-{
-  // TODO
 }
 
 Bit16u BX_CPU_C::x87_get_FCS(void)
@@ -330,14 +299,9 @@ bx_address BX_CPU_C::fpu_load_environment(bxInstruction_c *i)
 
     /* check for unmasked exceptions */
     if (FPU_PARTIAL_STATUS & ~FPU_CONTROL_WORD & FPU_CW_Exceptions_Mask)
-    {
-        /* set the B and ES bits in the status-word */
-        FPU_PARTIAL_STATUS |= FPU_SW_Summary | FPU_SW_Backward;
-    }
-    else {
-        /* clear the B and ES bits in the status-word */
-        FPU_PARTIAL_STATUS &= ~(FPU_SW_Summary | FPU_SW_Backward);
-    }
+        set_unmasked_fpu_exception();
+    else
+        clear_unmasked_fpu_exception();
 
     return (eaddr + offset) & asize_mask;
 }
@@ -354,15 +318,9 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::FLDCW(bxInstruction_c *i)
 
   /* check for unmasked exceptions */
   if (FPU_PARTIAL_STATUS & ~FPU_CONTROL_WORD & FPU_CW_Exceptions_Mask)
-  {
-      /* set the B and ES bits in the status-word */
-      FPU_PARTIAL_STATUS |= FPU_SW_Summary | FPU_SW_Backward;
-  }
+      set_unmasked_fpu_exception();
   else
-  {
-      /* clear the B and ES bits in the status-word */
-      FPU_PARTIAL_STATUS &= ~(FPU_SW_Summary | FPU_SW_Backward);
-  }
+      clear_unmasked_fpu_exception();
 
   BX_NEXT_INSTR(i);
 }
@@ -446,6 +404,8 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::FNCLEX(bxInstruction_c *i)
                    FPU_SW_Underflow|FPU_SW_Overflow|FPU_SW_Zero_Div|FPU_SW_Denormal_Op|
                    FPU_SW_Invalid);
 
+  clear_unmasked_fpu_exception();
+
   // do not update last fpu instruction pointer
 
   BX_NEXT_INSTR(i);
@@ -485,6 +445,8 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::FNSTENV(bxInstruction_c *i)
   FPU_CONTROL_WORD |= FPU_CW_Exceptions_Mask;
   /* clear the B and ES bits in the status word */
   FPU_PARTIAL_STATUS &= ~(FPU_SW_Backward|FPU_SW_Summary);
+
+  clear_unmasked_fpu_exception();
 
   BX_NEXT_INSTR(i);
 }

--- a/bochs/cpu/proc_ctrl.cc
+++ b/bochs/cpu/proc_ctrl.cc
@@ -172,6 +172,7 @@ void BX_CPU_C::enter_sleep_state(unsigned state)
 
   case BX_ACTIVITY_STATE_MWAIT:
   case BX_ACTIVITY_STATE_MWAIT_IF:
+  case BX_ACTIVITY_WAIT_FOR_X87:
     break;
 
   default:

--- a/bochs/cpu/sse_move.cc
+++ b/bochs/cpu/sse_move.cc
@@ -2,7 +2,7 @@
 // $Id$
 /////////////////////////////////////////////////////////////////////////
 //
-//   Copyright (c) 2003-2018 Stanislav Shwartsman
+//   Copyright (c) 2003-2026 Stanislav Shwartsman
 //          Written by Stanislav Shwartsman [sshwarts at sourceforge net]
 //
 //  This library is free software; you can redistribute it and/or
@@ -347,14 +347,10 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::FXRSTOR(bxInstruction_c *i)
   BX_CPU_THIS_PTR the_i387 = restore_i387;
 
   /* check for unmasked exceptions */
-  if (FPU_PARTIAL_STATUS & ~FPU_CONTROL_WORD & FPU_CW_Exceptions_Mask) {
-    /* set the B and ES bits in the status-word */
-    FPU_PARTIAL_STATUS |= FPU_SW_Summary | FPU_SW_Backward;
-  }
-  else {
-    /* clear the B and ES bits in the status-word */
-    FPU_PARTIAL_STATUS &= ~(FPU_SW_Summary | FPU_SW_Backward);
-  }
+  if (FPU_PARTIAL_STATUS & ~FPU_CONTROL_WORD & FPU_CW_Exceptions_Mask)
+    set_unmasked_fpu_exception();
+  else
+    clear_unmasked_fpu_exception();
 
 #if BX_SUPPORT_X86_64
   if (BX_CPU_THIS_PTR efer.get_FFXSR() && CPL == 0 && long64_mode()) {

--- a/bochs/cpu/xsave.cc
+++ b/bochs/cpu/xsave.cc
@@ -629,14 +629,10 @@ void BX_CPU_C::xrstor_x87_state(bxInstruction_c *i, bx_address offset)
   BX_CPU_THIS_PTR the_i387 = restore_i387;
 
   /* check for unmasked exceptions */
-  if (FPU_PARTIAL_STATUS & ~FPU_CONTROL_WORD & FPU_CW_Exceptions_Mask) {
-    /* set the B and ES bits in the status-word */
-    FPU_PARTIAL_STATUS |= FPU_SW_Summary | FPU_SW_Backward;
-  }
-  else {
-    /* clear the B and ES bits in the status-word */
-    FPU_PARTIAL_STATUS &= ~(FPU_SW_Summary | FPU_SW_Backward);
-  }
+  if (FPU_PARTIAL_STATUS & ~FPU_CONTROL_WORD & FPU_CW_Exceptions_Mask)
+    set_unmasked_fpu_exception();
+  else
+    clear_unmasked_fpu_exception();
 }
 
 void BX_CPU_C::xrstor_init_x87_state(void)

--- a/bochs/iodev/extfpuirq.cc
+++ b/bochs/iodev/extfpuirq.cc
@@ -70,7 +70,7 @@ void bx_extfpuirq_c::init(void)
 
 void bx_extfpuirq_c::reset(unsigned type)
 {
-  if (enabled /* && FERR */) {
+  if (enabled && FERR) {
     DEV_pic_lower_irq(13);
     bx_pc_system.set_IGNNE(true);
   }
@@ -92,7 +92,7 @@ void bx_extfpuirq_c::write(Bit32u address, Bit32u value, unsigned io_len)
   UNUSED(this_ptr);
 #endif // !BX_USE_EFI_SMF
 
-  if (BX_EXTFPUIRQ_THIS enabled /* && BX_EXTFPUIRQ_THIS FERR */) {
+  if (BX_EXTFPUIRQ_THIS enabled && BX_EXTFPUIRQ_THIS FERR) {
     DEV_pic_lower_irq(13);
     bx_pc_system.set_IGNNE(true);
   }

--- a/bochs/pc_system.cc
+++ b/bochs/pc_system.cc
@@ -70,6 +70,7 @@ void bx_pc_system_c::initialize(Bit32u ips)
   triggeredTimer = 0;
   HRQ = 0;
   kill_bochs_request = 0;
+  IGNNE = 0;
 
   // parameter 'ips' is the processor speed in Instructions-Per-Second
   m_ips = double(ips) / 1000000.0L;
@@ -81,7 +82,7 @@ void bx_pc_system_c::set_HRQ(bool val)
 {
   HRQ = val;
   if (val)
-    BX_CPU(0)->async_event = 1;
+    BX_CPU(BX_BOOTSTRAP_PROCESSOR)->async_event = 1;
 }
 
 void bx_pc_system_c::raise_INTR(void)
@@ -98,14 +99,6 @@ void bx_pc_system_c::clear_INTR(void)
     BX_INFO(("pc_system: Setting INTR=0 on bootstrap processor %d", BX_BOOTSTRAP_PROCESSOR));
 
   BX_CPU(BX_BOOTSTRAP_PROCESSOR)->clear_INTR();
-}
-
-void bx_pc_system_c::set_IGNNE(bool val)
-{
-  // TODO: Handle this in the CPU code
-#if BX_SUPPORT_FPU
-  BX_CPU(BX_BOOTSTRAP_PROCESSOR)->FPU_ignore_numeric_exception(val);
-#endif
 }
 
 //
@@ -240,6 +233,7 @@ void bx_pc_system_c::register_state(void)
   BXRS_DEC_PARAM_SIMPLE(list, lastTimeUsec);
   BXRS_DEC_PARAM_SIMPLE(list, usecSinceLast);
   BXRS_PARAM_BOOL(list, HRQ, HRQ);
+  BXRS_PARAM_BOOL(list, IGNNE, IGNNE);
 
   bx_list_c *timers = new bx_list_c(list, "timer");
   for (unsigned i = 0; i < numTimers; i++) {

--- a/bochs/pc_system.h
+++ b/bochs/pc_system.h
@@ -165,6 +165,9 @@ public:
   //    386:      20 bits
   bx_phy_address a20_mask;
 
+  // IGNNE# pin: Ignore x87 Numeric Exception
+  bool IGNNE;
+
   volatile bool kill_bochs_request;
 
   void set_HRQ(bool val);  // set the Hold ReQuest line
@@ -172,7 +175,8 @@ public:
   void raise_INTR(void);
   void clear_INTR(void);
 
-  void set_IGNNE(bool val);  // clear FPU error
+  bool get_IGNNE() { return IGNNE; }
+  void set_IGNNE(bool val) { IGNNE = val; }
 
   // Cpu and System Reset
   int Reset(unsigned type);


### PR DESCRIPTION
Attempt to implement #FERR and #IGNNE handling as well as MSDOS compatibility mode of handling x87 unmasked exceptions

Untested, should run extensive testing to see if x87 unmasked exceptions delivered properly.

I guess then adding a Bochs option to control this behavior will be the must:
extfpuirq: mode=...

And add deprecated FERR# and IGNNE#
