### PR TITLE
PIT: Don't create DSP events with no change in speaker level

### DIFF
--- a/bochs/iodev/pit.cc
+++ b/bochs/iodev/pit.cc
@@ -419,7 +419,11 @@ void bx_pit_c::speaker_handler(void *this_ptr, bool value)
 {
   bx_pit_c *class_ptr = (bx_pit_c*) this_ptr;
   if (class_ptr->s.timer.get_mode(2) != 3) {
-    DEV_speaker_set_line(value & class_ptr->s.speaker_data_on);
+    bool new_speaker_level = value & class_ptr->s.speaker_data_on;
+    if(class_ptr->s.speaker_level != new_speaker_level) {
+      DEV_speaker_set_line(new_speaker_level);
+      class_ptr->s.speaker_level = new_speaker_level;
+    }
   }
 }
 


### PR DESCRIPTION
**Description**: New DSP events are unconditionally created when the OUT2 handler is invoked while the PIT channel 2 timer is left running in any other mode than 3. This happens even when the speaker data enable bit is set to zero and there's no change in output level. In mode 2 this ends up flooding the terminal with "DSP event buffer full" messages, and at least on my system causes ALSA buffer underruns. The correct behaviour is already implemented in the PIT write handler for port 0x61. This patch just mirrors the existing behaviour to suppress calls to `bx_speaker_c::set_line()` if there is no change in output level.

**Reproduction**: The bug can be trivially reproduced by just configuring the PIT channel in mode 2. In my own code this triggers the bug:

```as
    mov   al, 0x94
    out   0x43, al
    mov   al, 1193182 / 4679
    out   0x42, al
    in    al, 0x61
    or    al, 1
    and   al, ~2
    out   0x61, al 
```

Because I never restore the timer it is left continually running at ~4.68kHz, and DSP events are created accordingly. This is not a problem so long as PIT timer 2 runs in mode 3.

**Fix**: The fix is very simple and just mirrors what already exists in the aforementioned write handler. The `set_line` function is not called if there is no change in speaker level, and if there is, then the new speaker level is stored for next time.