### PR TITLE
i486dx4: expose CR4 to support VME/PVI

### DIFF
--- a/bochs/bx_debug/dbg_main.cc
+++ b/bochs/bx_debug/dbg_main.cc
@@ -1121,9 +1121,12 @@ void bx_dbg_info_control_regs_command(unsigned cpu)
   dbg_printf("    PCD=page-level cache disable=%d\n", (cr3>>4) & 1);
   dbg_printf("    PWT=page-level write-through=%d\n", (cr3>>3) & 1);
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   Bit32u cr4 = SIM->get_param_num("CR4", dbg_cpu_list[cpu])->get();
   dbg_printf("CR4=0x%08x: %s\n", cr4, stringify_CR4(cr4, s));
+#endif
+
+#if BX_CPU_LEVEL >= 5
 #if BX_SUPPORT_X86_64
   if (BX_CPU(cpu)->is_cpu_extension_supported(BX_ISA_LONG_MODE)) {
     dbg_printf("CR8: 0x%x\n", BX_CPU(cpu)->get_cr8());

--- a/bochs/cpu/cpu.cc
+++ b/bochs/cpu/cpu.cc
@@ -638,7 +638,7 @@ void BX_CPU_C::prefetch(void)
 #endif
   {
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
     if (USER_PL && BX_CPU_THIS_PTR get_VIP() && BX_CPU_THIS_PTR get_VIF()) {
       if (BX_CPU_THIS_PTR cr4.get_PVI() || (v8086_mode() && BX_CPU_THIS_PTR cr4.get_VME())) {
         BX_ERROR(("prefetch: inconsistent VME state"));

--- a/bochs/cpu/cpu.h
+++ b/bochs/cpu/cpu.h
@@ -1032,18 +1032,18 @@ public: // for now...
   bx_cr0_t   cr0;
   bx_address cr2;
   bx_address cr3;
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   bx_cr4_t   cr4;
   bx_address cr4_suppmask;
 #if BX_SUPPORT_X86_64
   unsigned linaddr_width;
 #endif
-
-  bx_efer_t efer;
-  Bit32u efer_suppmask;
 #endif
 
 #if BX_CPU_LEVEL >= 5
+  bx_efer_t efer;
+  Bit32u efer_suppmask;
+
   // TSC: Time Stamp Counter
   // Instead of storing a counter and incrementing it every instruction, we
   // remember the time in ticks that it was reset to zero.  With a little
@@ -4854,7 +4854,7 @@ public: // for now...
   BX_SMF bool SetCR0(bxInstruction_c *i, bx_address val);
   BX_SMF bool check_CR0(bx_address val, bool vmenter = false) BX_CPP_AttrRegparmN(1);
   BX_SMF bool SetCR3(bx_address val) BX_CPP_AttrRegparmN(1);
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   BX_SMF bool SetCR4(bxInstruction_c *i, bx_address val);
   BX_SMF bool check_CR4(bx_address val) BX_CPP_AttrRegparmN(1);
   BX_SMF bx_address get_cr4_allow_mask(void);
@@ -4871,7 +4871,7 @@ public: // for now...
 #endif
 
   BX_SMF bx_address read_CR0(void);
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   BX_SMF bx_address read_CR4(void);
 #endif
 #if BX_CPU_LEVEL >= 6

--- a/bochs/cpu/crregs.cc
+++ b/bochs/cpu/crregs.cc
@@ -499,7 +499,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::MOV_CR3Rd(bxInstruction_c *i)
 
 void BX_CPP_AttrRegparmN(1) BX_CPU_C::MOV_CR4Rd(bxInstruction_c *i)
 {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   // CPL is always 0 in real mode
   if (/* !real_mode() && */ CPL!=0) {
     BX_ERROR(("%s: CPL!=0 not in real mode", i->getIaOpcodeNameShort()));
@@ -604,7 +604,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::MOV_RdCR3(bxInstruction_c *i)
 
 void BX_CPP_AttrRegparmN(1) BX_CPU_C::MOV_RdCR4(bxInstruction_c *i)
 {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   // CPL is always 0 in real mode
   if (/* !real_mode() && */ CPL!=0) {
     BX_ERROR(("%s: CPL!=0 not in real mode", i->getIaOpcodeNameShort()));
@@ -971,7 +971,7 @@ bx_address BX_CPU_C::read_CR0(void)
   return cr0_val;
 }
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
 bx_address BX_CPU_C::read_CR4(void)
 {
   bx_address cr4_val = BX_CPU_THIS_PTR cr4.get();
@@ -1170,7 +1170,7 @@ bool BX_CPU_C::SetCR0(bxInstruction_c *i, bx_address val)
   return true;
 }
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
 bx_address BX_CPU_C::get_cr4_allow_mask(void)
 {
   bx_address allowMask = 0;
@@ -1213,6 +1213,7 @@ bx_address BX_CPU_C::get_cr4_allow_mask(void)
   if (is_cpu_extension_supported(BX_ISA_VME))
     allowMask |= BX_CR4_VME_MASK | BX_CR4_PVI_MASK;
 
+#if BX_CPU_LEVEL >= 5
   if (is_cpu_extension_supported(BX_ISA_PENTIUM))
     allowMask |= BX_CR4_TSD_MASK;
 
@@ -1305,7 +1306,8 @@ bx_address BX_CPU_C::get_cr4_allow_mask(void)
   if (is_cpu_extension_supported(BX_ISA_FRED))
     allowMask |= BX_CR4_FRED_MASK;
 #endif
-#endif
+#endif // #if BX_CPU_LEVEL >= 6
+#endif // #if BX_CPU_LEVEL >= 5
 
   return allowMask;
 }
@@ -1441,7 +1443,7 @@ bool BX_CPU_C::SetCR4(bxInstruction_c *i, bx_address val)
 
   return true;
 }
-#endif // BX_CPU_LEVEL >= 5
+#endif // BX_CPU_LEVEL >= 4
 
 bool BX_CPP_AttrRegparmN(1) BX_CPU_C::SetCR3(bx_address val)
 {
@@ -1900,6 +1902,8 @@ void BX_CPU_C::xsave_xrestor_init(void)
   // XCR0[19]: APX state (not implemented)
 }
 
+#endif
+
 #if BX_CPU_LEVEL >= 5
 
 Bit32u BX_CPU_C::get_efer_allow_mask(void)
@@ -1928,6 +1932,8 @@ Bit32u BX_CPU_C::get_efer_allow_mask(void)
 }
 
 #endif
+
+#if BX_CPU_LEVEL >= 6
 
 Bit32u BX_CPU_C::get_xcr0_allow_mask(void)
 {

--- a/bochs/cpu/crregs.h
+++ b/bochs/cpu/crregs.h
@@ -86,8 +86,8 @@ struct bx_cr0_t {
   BX_CPP_INLINE void set32(Bit32u val32) { val = val32 | 0x10; }
 };
 
-#if BX_CPU_LEVEL >= 5
 
+#if BX_CPU_LEVEL >= 4
 #define BX_CR4_VME_MASK             (1 << 0)
 #define BX_CR4_PVI_MASK             (1 << 1)
 #define BX_CR4_TSD_MASK             (1 << 2)
@@ -131,6 +131,7 @@ struct bx_cr4_t {
 
   IMPLEMENT_CRREG_ACCESSORS(VME, 0);
   IMPLEMENT_CRREG_ACCESSORS(PVI, 1);
+#if BX_CPU_LEVEL >= 5
   IMPLEMENT_CRREG_ACCESSORS(TSD, 2);
   IMPLEMENT_CRREG_ACCESSORS(DE,  3);
   IMPLEMENT_CRREG_ACCESSORS(PSE, 4);
@@ -163,14 +164,17 @@ struct bx_cr4_t {
 #if BX_SUPPORT_FRED
   IMPLEMENT_UPPER_CRREG_ACCESSORS(FRED, 32);
 #endif
+#endif  // #if BX_CPU_LEVEL >= 5
 
   BX_CPP_INLINE bx_address get() const { return val; }
   BX_CPP_INLINE void set(bx_address value) { val = value; }
 };
 
+#if BX_CPU_LEVEL >= 5
 const bx_address BX_CR4_FLUSH_TLB_MASK = (BX_CR4_PSE_MASK | BX_CR4_PAE_MASK | BX_CR4_PGE_MASK | BX_CR4_LA57_MASK | BX_CR4_PCIDE_MASK | BX_CR4_SMEP_MASK | BX_CR4_SMAP_MASK | BX_CR4_PKE_MASK | BX_CR4_CET_MASK | BX_CR4_PKS_MASK | BX_CR4_LASS_MASK);
+#endif
 
-#endif  // #if BX_CPU_LEVEL >= 5
+#endif  // #if BX_CPU_LEVEL >= 4
 
 struct bx_dr6_t {
   Bit32u val; // 32bit value of register

--- a/bochs/cpu/debugstuff.cc
+++ b/bochs/cpu/debugstuff.cc
@@ -339,7 +339,7 @@ void BX_CPU_C::debug(bx_address offset)
     (unsigned) BX_CPU_THIS_PTR sregs[BX_SEG_REG_GS].cache.u.segment.d_b));
 
   Bit32u cr0 = BX_CPU_THIS_PTR cr0.get32();
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   bx_address cr4 = BX_CPU_THIS_PTR cr4.get();
 #endif
 
@@ -369,7 +369,7 @@ void BX_CPU_C::debug(bx_address offset)
     BX_INFO(("| CR0=0x%08x: %s", cr0, stringify_CR0(cr0, s)));
     BX_INFO(("| CR2=0x%08x", (unsigned) BX_CPU_THIS_PTR cr2));
     BX_INFO(("| CR3=0x%08x", (unsigned) BX_CPU_THIS_PTR cr3));
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
     BX_INFO(("| CR4=0x%08x: %s", cr4, stringify_CR4(cr4, s)));
 #endif
   }

--- a/bochs/cpu/decoder/ia_opcodes.def
+++ b/bochs/cpu/decoder/ia_opcodes.def
@@ -487,11 +487,11 @@ bx_define_opcode(BX_IA_LMSW_Ew, "lmsw", "lmsw", &BX_CPU_C::LMSW_Ew, &BX_CPU_C::L
 bx_define_opcode(BX_IA_MOV_CR0Rd, "mov", "movl", NULL, &BX_CPU_C::MOV_CR0Rd, 0, OP_Cd, OP_Ed, OP_NONE, OP_NONE, BX_TRACE_END)
 bx_define_opcode(BX_IA_MOV_CR2Rd, "mov", "movl", NULL, &BX_CPU_C::MOV_CR2Rd, 0, OP_Cd, OP_Ed, OP_NONE, OP_NONE, 0)
 bx_define_opcode(BX_IA_MOV_CR3Rd, "mov", "movl", NULL, &BX_CPU_C::MOV_CR3Rd, 0, OP_Cd, OP_Ed, OP_NONE, OP_NONE, BX_TRACE_END)
-bx_define_opcode(BX_IA_MOV_CR4Rd, "mov", "movl", NULL, &BX_CPU_C::MOV_CR4Rd, BX_ISA_PENTIUM, OP_Cd, OP_Ed, OP_NONE, OP_NONE, BX_TRACE_END)
+bx_define_opcode(BX_IA_MOV_CR4Rd, "mov", "movl", NULL, &BX_CPU_C::MOV_CR4Rd, BX_ISA_486, OP_Cd, OP_Ed, OP_NONE, OP_NONE, BX_TRACE_END)
 bx_define_opcode(BX_IA_MOV_RdCR0, "mov", "movl", NULL, &BX_CPU_C::MOV_RdCR0, 0, OP_Ed, OP_Cd, OP_NONE, OP_NONE, 0)
 bx_define_opcode(BX_IA_MOV_RdCR2, "mov", "movl", NULL, &BX_CPU_C::MOV_RdCR2, 0, OP_Ed, OP_Cd, OP_NONE, OP_NONE, 0)
 bx_define_opcode(BX_IA_MOV_RdCR3, "mov", "movl", NULL, &BX_CPU_C::MOV_RdCR3, 0, OP_Ed, OP_Cd, OP_NONE, OP_NONE, 0)
-bx_define_opcode(BX_IA_MOV_RdCR4, "mov", "movl", NULL, &BX_CPU_C::MOV_RdCR4, BX_ISA_PENTIUM, OP_Ed, OP_Cd, OP_NONE, OP_NONE, 0)
+bx_define_opcode(BX_IA_MOV_RdCR4, "mov", "movl", NULL, &BX_CPU_C::MOV_RdCR4, BX_ISA_486, OP_Ed, OP_Cd, OP_NONE, OP_NONE, 0)
 bx_define_opcode(BX_IA_MOV_RdDd, "mov", "movl", NULL, &BX_CPU_C::MOV_RdDd, 0, OP_Ed, OP_Dd, OP_NONE, OP_NONE, 0)
 bx_define_opcode(BX_IA_MOV_DdRd, "mov", "movl", NULL, &BX_CPU_C::MOV_DdRd, 0, OP_Dd, OP_Ed, OP_NONE, OP_NONE, BX_TRACE_END)
 

--- a/bochs/cpu/flag_ctrl.cc
+++ b/bochs/cpu/flag_ctrl.cc
@@ -66,7 +66,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::CLI(bxInstruction_c *i)
 
   if (protected_mode())
   {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
     if (BX_CPU_THIS_PTR cr4.get_PVI() && (CPL == 3))
     {
       if (IOPL < 3) {
@@ -86,7 +86,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::CLI(bxInstruction_c *i)
   else if (v8086_mode())
   {
     if (IOPL != 3) {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
       if (BX_CPU_THIS_PTR cr4.get_VME()) {
         BX_CPU_THIS_PTR clear_VIF();
         BX_NEXT_INSTR(i);
@@ -108,7 +108,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::STI(bxInstruction_c *i)
 
   if (protected_mode())
   {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
     if (BX_CPU_THIS_PTR cr4.get_PVI())
     {
       if (CPL == 3 && IOPL < 3) {
@@ -131,7 +131,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::STI(bxInstruction_c *i)
   else if (v8086_mode())
   {
     if (IOPL != 3) {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
       if (BX_CPU_THIS_PTR cr4.get_VME() && BX_CPU_THIS_PTR get_VIP() == 0)
       {
         BX_CPU_THIS_PTR assert_VIF();
@@ -184,7 +184,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::PUSHF_Fw(bxInstruction_c *i)
 
   if (v8086_mode()) {
     if (BX_CPU_THIS_PTR get_IOPL() < 3) {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
       if (BX_CPU_THIS_PTR cr4.get_VME()) {
         flags |= EFlagsIOPLMask;
         if (BX_CPU_THIS_PTR get_VIF())
@@ -230,7 +230,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::POPF_Fw(bxInstruction_c *i)
   }
   else if (v8086_mode()) {
     if (BX_CPU_THIS_PTR get_IOPL() < 3) {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
       if (BX_CPU_THIS_PTR cr4.get_VME()) {
 
         if (((flags16 & EFlagsIFMask) && BX_CPU_THIS_PTR get_VIP()) ||

--- a/bochs/cpu/flag_ctrl_pro.cc
+++ b/bochs/cpu/flag_ctrl_pro.cc
@@ -73,7 +73,7 @@ BX_CPU_C::writeEFlags(Bit32u flags, Bit32u changeMask)
   if (BX_CPUID_SUPPORT_ISA_EXTENSION(BX_ISA_486))
     supportMask |= (EFlagsIDMask | EFlagsACMask); // ID/AC
 #endif
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   if (BX_CPUID_SUPPORT_ISA_EXTENSION(BX_ISA_VME))
     supportMask |= (EFlagsVIPMask | EFlagsVIFMask); // VIP/VIF
 #endif

--- a/bochs/cpu/init.cc
+++ b/bochs/cpu/init.cc
@@ -371,7 +371,7 @@ void BX_CPU_C::register_state(void)
   BXRS_HEX_PARAM_FIELD(cpu, CR0, cr0.val);
   BXRS_HEX_PARAM_FIELD(cpu, CR2, cr2);
   BXRS_HEX_PARAM_FIELD(cpu, CR3, cr3);
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   BXRS_HEX_PARAM_FIELD(cpu, CR4, cr4.val);
 #endif
 
@@ -1072,7 +1072,7 @@ void BX_CPU_C::reset(unsigned source)
   BX_CPU_THIS_PTR cr3 = 0;
 #endif
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   BX_CPU_THIS_PTR cr4.set(0);
   BX_CPU_THIS_PTR cr4_suppmask = get_cr4_allow_mask();
 #if BX_SUPPORT_X86_64
@@ -1461,7 +1461,7 @@ void BX_CPU_C::assert_checks(void)
   if (! check_CR0(BX_CPU_THIS_PTR cr0.get32()))
     BX_PANIC(("assert_checks: CR0 consistency checks failed !"));
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   // check CR4 consistency
   if (! check_CR4(BX_CPU_THIS_PTR cr4.get()))
     BX_PANIC(("assert_checks: CR4 consistency checks failed !"));

--- a/bochs/cpu/smm.cc
+++ b/bochs/cpu/smm.cc
@@ -149,7 +149,7 @@ void BX_CPU_C::enter_system_management_mode(void)
   BX_CPU_THIS_PTR cr0.set_TS(0); // no task switch (bit 3)
   BX_CPU_THIS_PTR cr0.set_PG(0); // paging disabled (bit 31)
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   BX_CPU_THIS_PTR cr4.set(0);
 #endif
 
@@ -553,8 +553,10 @@ void BX_CPU_C::smram_save_state(Bit32u *saved_state)
 
   SMRAM_FIELD(saved_state, SMRAM_FIELD_CR0) = BX_CPU_THIS_PTR cr0.get32();
   SMRAM_FIELD(saved_state, SMRAM_FIELD_CR3) = BX_CPU_THIS_PTR cr3;
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   SMRAM_FIELD(saved_state, SMRAM_FIELD_CR4) = BX_CPU_THIS_PTR cr4.get();
+#endif
+#if BX_CPU_LEVEL >= 5
   SMRAM_FIELD(saved_state, SMRAM_FIELD_EFER) = BX_CPU_THIS_PTR efer.get32();
 #endif
   SMRAM_FIELD(saved_state, SMRAM_FIELD_DR6) = BX_CPU_THIS_PTR dr6.get32();
@@ -603,8 +605,10 @@ bool BX_CPU_C::smram_restore_state(const Bit32u *saved_state)
 
   smm_state.cr0.val = SMRAM_FIELD(saved_state, SMRAM_FIELD_CR0);
   smm_state.cr3 = SMRAM_FIELD(saved_state, SMRAM_FIELD_CR3);
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   smm_state.cr4.val = SMRAM_FIELD(saved_state, SMRAM_FIELD_CR4);
+#endif
+#if BX_CPU_LEVEL >= 5
   smm_state.efer.val = SMRAM_FIELD(saved_state, SMRAM_FIELD_EFER);
 #endif
 
@@ -710,7 +714,7 @@ bool BX_CPU_C::resume_from_system_management_mode(BX_SMM_State *smm_state)
     return false;
   }
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   if (!check_CR4(smm_state->cr4.get())) {
     BX_PANIC(("SMM restore: CR4 consistency check failed !"));
     return false;
@@ -718,7 +722,7 @@ bool BX_CPU_C::resume_from_system_management_mode(BX_SMM_State *smm_state)
 #endif
 
   BX_CPU_THIS_PTR cr0.set32(smm_state->cr0.get32());
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   BX_CPU_THIS_PTR cr4.set(smm_state->cr4.get());
 #endif
   BX_CPU_THIS_PTR cr3 = smm_state->cr3;

--- a/bochs/cpu/smm.h
+++ b/bochs/cpu/smm.h
@@ -85,8 +85,10 @@ struct BX_SMM_State
 
   bx_cr0_t   cr0;
   bx_address cr3;
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   bx_cr4_t   cr4;
+#endif
+#if BX_CPU_LEVEL >= 5
   bx_efer_t efer;
 #endif
 

--- a/bochs/cpu/vm8086.cc
+++ b/bochs/cpu/vm8086.cc
@@ -123,7 +123,7 @@ void BX_CPU_C::stack_return_to_v86(Bit32u new_eip, Bit32u raw_cs_selector, Bit32
 #endif
 }
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   #define BX_CR4_VME_ENABLED (BX_CPU_THIS_PTR cr4.get_VME())
 #else
   #define BX_CR4_VME_ENABLED (0)
@@ -143,7 +143,7 @@ void BX_CPU_C::iret16_stack_return_from_v86(bxInstruction_c *i)
   cs_raw  = pop_16();
   flags16 = pop_16();
 
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   if (BX_CPU_THIS_PTR cr4.get_VME() && BX_CPU_THIS_PTR get_IOPL() < 3)
   {
     if (((flags16 & EFlagsIFMask) && BX_CPU_THIS_PTR get_VIP()) ||
@@ -202,7 +202,7 @@ void BX_CPU_C::iret32_stack_return_from_v86(bxInstruction_c *i)
 
 bool BX_CPU_C::v86_redirect_interrupt(Bit8u vector)
 {
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
   if (BX_CPU_THIS_PTR cr4.get_VME())
   {
     bx_address tr_base = BX_CPU_THIS_PTR tr.cache.u.segment.base;

--- a/bochs/gui/enh_dbg.cc
+++ b/bochs/gui/enh_dbg.cc
@@ -1259,7 +1259,7 @@ void InitRegObjects()
         RegObject[cpu][CR0_Rnum] = SIM->get_param_num("CR0", cpu_list);
         RegObject[cpu][CR2_Rnum] = SIM->get_param_num("CR2", cpu_list);
         RegObject[cpu][CR3_Rnum] = SIM->get_param_num("CR3", cpu_list);
-#if BX_CPU_LEVEL >= 5
+#if BX_CPU_LEVEL >= 4
         RegObject[cpu][CR4_Rnum] = SIM->get_param_num("CR4", cpu_list);
 #endif
 #if BX_CPU_LEVEL >= 6


### PR DESCRIPTION
Hi,

Just another reasonably small patch, because I ran into a bit of a problem while writing some code for CR4 detection.

**Description**: Commit f30cdc367 introduces emulation of the i486DX4 CPU which is supported when compiled with `--enable-cpu-level=4`, but the commit does not expose the `MOV_RdCR4`/`MOV_CR4Rd` instructions to the decoder with the `BX_ISA_486` feature. I think I understand why, because only the later i486 CPUs like the DX4 actually has the CR4 register. However, this leaves VME/PVI broken when emulating these CPUs, as the only way to enable them is through the CR4 register. The assembly code that breaks is:

```as
check_cpuid:
    xor   eax, eax
    pusha
    pushfd
    pushfd
    pushfd
    btr   dword [esp], 21
    popfd
    pushfd
    pop   eax
    bts   dword [esp], 21
    popfd
    pushfd
    pop   ecx
    popfd
    xor   ecx, eax
    popa
    setnz al
    ret

check_cr4:
    pusha
    call  check_cpuid
    jz    check_cr4_ret
    cpuid
    ; CPUID leaf 1 test for:
    ; CR4.MCE, CR4.PAE, CR4.TSD,
    ; CR4.PSE, CR4.DE, CR4.VME
    ; Definitely got CR4 if non-zero.
    test  dl, 0xDE
check_cr4_ret:
    popa
    ret
```

This patch fixes that by changing the related lines in `cpu/decoder/ia_opcodes.def` to make the instructions valid for `BX_ISA_486`. It also corrects compilation with `--enable-cpu-level=4` by moving some `BX_CPU_LEVEL >= 5` guards so that features limited to these CPUs are correctly guarded, and lowers others to `BX_CPU_LEVEL >= 4` where appropriate. There is also an additional small fix, where a CPU level 6 guard has been split up. Specifically, it fixes that a `BX_CPU_LEVEL >= 6` guard encloses `BX_CPU_C::get_efer_allow_mask()` which makes a build with `--enable-cpu-level=5` fail. This function is now guarded with `BX_CPU_LEVEL >= 5`, followed again by a guard for CPU level 6.

The Intel i486 manual documents the existence of CR4 and its defined bits in Figure 4-6, p. 4-17. It also documents the PSE bit as present, but I cannot find any real i486 architecture CPUs that actually support this bit. The manual qualifies that usage of CR4 and the features controlled by it must first be checked by the CPUID instruction.

Please correct me if I am wrong about this, but: In terms of SMM I have simply retained the `SMRAM_FIELD_CR4` field, which I think should be sufficient for emulation purposes. The same manual documents that CR4 is saved in the SMM save state, but I have not been able to find public documentation of its actual location. The i486 manual simply says it is within a reserved region, though the existing mapping from 0x7F14 does exist within a reserved region in the i486 SMRAM state save map on page 8-9.

**Testing**: I have done manual testing under both `--enable-cpu-level=4` and `--enable-cpu-level=5`, and writes of bit 0 and 1 on the i486dx4 model behave correctly, and any higher bits cause the CPU to fault as intended. The i386 model still produces #UD exceptions when trying to access CR4, and CPU level >=5 models also behave correctly with setting/unsetting other bits, e.g. PSE etc.

I will say one thing, which is that it would possibly be better if the `BX_ISA_486` feature was not used for enabling these instructions in `cpu/decoder/ia_opcodes.def`, for the aforementioned reason that not all i486 CPUs actually have CR4. I don't know how appropriate it would be to define something like a `BX_ISA_CR4` feature, because on its own its not really an ISA like modelled by `BX_ISA_SVM` etc. I'd be very open to changing that if requested, because this patch is obviously not generally correct for all future level 4 CPUs.

Regards,
Yggdrasill