### PR TITLE
memory: fix 32-bit truncation of BX_PCI_HOLE_END

### DIFF
--- a/bochs/memory/memory-bochs.h
+++ b/bochs/memory/memory-bochs.h
@@ -45,13 +45,13 @@ const Bit32u EXROM_MASK = EXROMSIZE-1;
 // Guest physical memory layout helpers (for configurations with a 3GB to 4GB PCI MMIO hole).
 // When RAM is >3GB, RAM from 3GB to 4GB is typically remapped above 4GB so that
 // the 3GB to 4GB region can be used for PCI MMIO.
-const bx_phy_address BX_PCI_HOLE_START = (bx_phy_address)0xC0000000ULL;   // 3GB
-const bx_phy_address BX_PCI_HOLE_END   = (bx_phy_address)0x100000000ULL;  // 4GB
-const bx_phy_address BX_PCI_HOLE_SIZE  = (bx_phy_address)(BX_PCI_HOLE_END - BX_PCI_HOLE_START);
+const bx_phy_address BX_PCI_HOLE_START = 0xC0000000ULL;   // 3GB
+const bx_phy_address BX_PCI_HOLE_LAST  = 0xFFFFFFFFULL;  // 4GB - 1
+const bx_phy_address BX_PCI_HOLE_SIZE  = BX_PCI_HOLE_LAST - BX_PCI_HOLE_START + 1;
 
 static BX_CPP_INLINE bool bx_is_pci_hole_addr(bx_phy_address gpa)
 {
-  return (gpa >= BX_PCI_HOLE_START) && (gpa < BX_PCI_HOLE_END);
+  return (gpa >= BX_PCI_HOLE_START) && (gpa <= BX_PCI_HOLE_LAST);
 }
 
 // Translate guest physical address to Bochs linear RAM backing-store offset.
@@ -59,9 +59,11 @@ static BX_CPP_INLINE bool bx_is_pci_hole_addr(bx_phy_address gpa)
 // - For addresses < 4GB, keep the address as-is (including the PCI hole region for MMIO).
 static BX_CPP_INLINE bx_phy_address bx_translate_gpa_to_linear(bx_phy_address gpa)
 {
-  if (gpa >= BX_PCI_HOLE_END) {
+#if BX_PHY_ADDRESS_LONG
+  if (gpa > BX_PCI_HOLE_LAST) {
     return gpa - BX_PCI_HOLE_SIZE;
   }
+#endif
   return gpa;
 }
 

--- a/bochs/memory/memory-bochs.h
+++ b/bochs/memory/memory-bochs.h
@@ -45,8 +45,8 @@ const Bit32u EXROM_MASK = EXROMSIZE-1;
 // Guest physical memory layout helpers (for configurations with a 3GB to 4GB PCI MMIO hole).
 // When RAM is >3GB, RAM from 3GB to 4GB is typically remapped above 4GB so that
 // the 3GB to 4GB region can be used for PCI MMIO.
-const bx_phy_address BX_PCI_HOLE_START = 0xC0000000ULL;   // 3GB
-const bx_phy_address BX_PCI_HOLE_LAST  = 0xFFFFFFFFULL;  // 4GB - 1
+const bx_phy_address BX_PCI_HOLE_START = 0xC0000000;  // 3GB
+const bx_phy_address BX_PCI_HOLE_LAST  = 0xFFFFFFFF;  // 4GB - 1
 const bx_phy_address BX_PCI_HOLE_SIZE  = BX_PCI_HOLE_LAST - BX_PCI_HOLE_START + 1;
 
 static BX_CPP_INLINE bool bx_is_pci_hole_addr(bx_phy_address gpa)


### PR DESCRIPTION
Hi,

Another small patch, which I worked around in PR #828 by compiling with `--enable-long-phy-address`. After some debugging and looking around I finally found the source of the problem.

**Description**: In `memory/memory-bochs.h` there are the following definitions and inlined functions, which assume that `bx_phy_address` is a type able to represent 4GiB:

```cpp
const bx_phy_address BX_PCI_HOLE_START = (bx_phy_address)0xC0000000ULL;   // 3GB
const bx_phy_address BX_PCI_HOLE_END   = (bx_phy_address)0x100000000ULL;  // 4GB
const bx_phy_address BX_PCI_HOLE_SIZE  = (bx_phy_address)(BX_PCI_HOLE_END - BX_PCI_HOLE_START);

static BX_CPP_INLINE bool bx_is_pci_hole_addr(bx_phy_address gpa)
{
  return (gpa >= BX_PCI_HOLE_START) && (gpa < BX_PCI_HOLE_END);
}

static BX_CPP_INLINE bx_phy_address bx_translate_gpa_to_linear(bx_phy_address gpa)
{
  if (gpa >= BX_PCI_HOLE_END) {
    return gpa - BX_PCI_HOLE_SIZE;
  }
  return gpa;
}
```

When `./configure` is run with the option `--enable-cpu-level=4` then the default is to define `BX_PHY_ADDRESS_LONG` as zero. The problem then becomes apparent when `config.h` does this, and consequently `BX_PCI_HOLE_END` truncates to zero:

```cpp
#if BX_PHY_ADDRESS_LONG
typedef Bit64u bx_phy_address;
#if BX_CPU_LEVEL == 5
  #define BX_PHY_ADDRESS_WIDTH 36
#else
  #define BX_PHY_ADDRESS_WIDTH 40
#endif
#else
typedef Bit32u bx_phy_address;
#define BX_PHY_ADDRESS_WIDTH 32
#endif
```

This breaks the comparisons in both `bx_is_pci_hole_addr` and `bx_translate_gpa_to_linear`, where the former always evaluates to false and will never detect a MMIO hole address, and the latter will always evaluate to true because it is comparing >= 0 for an unsigned value.

What follows immediately after is that it remaps an address that it should really leave unchanged, and corrupts any memory address that passes through this function with a 32-bit `bx_phy_address`. This ends up breaking the stack almost immediately during the init phase, at the following instructions (in my most recent build against master):

```
        (0xfe0a4) mov ax, 0xfffe
        (0xfe0a7) mov sp, ax
```

The stack ends up with "illegal address" in the debugger, where the ret instruction breaks as the stack is non-functional:

```
        (0xf064f) mov ax, cs
        (0xf0651) ret
```

Because the stack is broken and the return address is garbage, the emulator ends up repeatedly outputting "prefetch: EIP [00010000] > CS.limit [0000ffff]" to the terminal.

**Fix**: Is reasonably simple. First I have removed the casts, because the casts are what suppressed the compiler truncation warnings with `--disable-long-phy-address` to begin with. Instead of using a half-open range of [`BX_PCI_HOLE_START`, `BX_PCI_HOLE_END`), the latter variable has been renamed to `BX_PCI_HOLE_LAST` and the value is now `0xFFFFFFFF`. I have adjusted the size calculation and comparison operators accordingly, and also made the `bx_translate_gpa_to_linear` comparison guarded by `BX_PHY_ADDRESS_LONG` because the comparison will always be false in a build with 32-bit `bx_phy_address` anyway.

Kind regards,
Yggdrasill