### PR TITLE
Fix stale opcode comment above BxOpcodeTableC0 (was D0)

### DIFF
--- a/bochs/cpu/decoder/fetchdecode_opmap.h
+++ b/bochs/cpu/decoder/fetchdecode_opmap.h
@@ -1008,7 +1008,7 @@ static const Bit64u BxOpcodeTableB8xBF[] = {
   last_opcode(ATTR_OS16, BX_IA_MOV_EwIw)
 };
 
-// opcode D0
+// opcode C0
 static const Bit64u BxOpcodeTableC0[] = {
   form_opcode(ATTR_NNN0, BX_IA_ROL_EbIb),
   form_opcode(ATTR_NNN1, BX_IA_ROR_EbIb),


### PR DESCRIPTION
The comment above `BxOpcodeTableC0` in `cpu/decoder/fetchdecode_opmap.h` read "opcode D0", but the table encodes the shift/rotate-by-Ib group (ROL/ROR/RCL/RCR/SHL/SHR/SAR Eb,Ib), which is opcode C0. D0 is the separate shift-by-1 group with no immediate operand. The comment did not match the table it labels.

Found while cross-checking a standalone i386 instruction-encoding inventory against fetchdecode_opmap.h's table identifiers vs. its `// opcode NN` comments.