### PR TITLE
Fix PSRLQ behavior for a shift count of 64

### DIFF
--- a/bochs/cpu/simd_int.h
+++ b/bochs/cpu/simd_int.h
@@ -1337,7 +1337,7 @@ BX_CPP_INLINE void xmm_psrld(BxPackedXmmRegister *op, Bit64u shift_64)
 
 BX_CPP_INLINE void xmm_psrlq(BxPackedXmmRegister *op, Bit64u shift_64)
 {
-  if(shift_64 > 64) op->clear();
+  if(shift_64 > 63) op->clear();
   else
   {
     Bit8u shift = (Bit8u) shift_64;


### PR DESCRIPTION
## Problem

`PSRLQ` must clear every destination qword when the unsigned shift
count is greater than 63.

The `xmm_psrlq` helper currently checks for counts greater than 64:

```cpp
if(shift_64 > 64) op->clear();
```

This allows a count of exactly 64 to reach the shift operation and
evaluate a 64-bit C++ right shift by 64. That operation is undefined
behavior. Depending on the host and compiler, the effective shift
count can become zero and leave the destination unchanged.

For example:

```
bytes:       66 0f 73 d0 40
instruction: psrlq xmm0, 0x40
input xmm0:  0000000000000000:fffffffffffe65ed
expected:    0000000000000000:0000000000000000
before fix:  0000000000000000:fffffffffffe65ed
```

The helper is shared by the legacy SSE2, VEX, and EVEX PSRLQ paths,
including immediate-count and register/memory-count forms.

## Fix

Change the boundary check from > 64 to > 63, matching the
architectural behavior and the existing xmm_psllq and MMX PSRLQ
implementations.

This also prevents a shift exponent equal to the width of the C++
operand.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2B, section “PSRLW/PSRLD/PSRLQ—Shift Packed Data Right
Logical,” specifies that when the shift count for a quadword is greater
than 63, the destination operand is set to zero. Therefore, 64 is the
first count that must clear every destination qword.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2B](https://cdrdv2-public.intel.com/922481/253667-092-sdm-vol-2b.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

A temporary standalone test invoked the production xmm_psrlq
helper with two nonzero, distinguishable qword lanes and counts:

Before the fix, UBSan failed at count 64 with:
```
runtime error: shift exponent 64 is too large for 64-bit type
qword lanes, and UBSan reported no invalid shift.
```
```sh
cd bochs
  CFLAGS='-Wall -O2 -fomit-frame-pointer -pipe' \
  CXXFLAGS='-Wall -O2 -fomit-frame-pointer -pipe' \
    --enable-x86-64 \
    --enable-avx \
    --enable-evex \
    --with-nogui

make -j4
```

I didn't see any in-tree CPU instruction test harness, so I kept this PR fix-only. I’m happy to add coverage using any test setup you might like, if needed.