### PR TITLE
Fix building on OpenBSD / NetBSD

### DIFF
--- a/bochs/iodev/network/eth_slirp.cc
+++ b/bochs/iodev/network/eth_slirp.cc
@@ -65,6 +65,10 @@ typedef ssize_t slirp_ssize_t;
 #include "slirp/libslirp.h"
 #endif
 #include <signal.h>
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <sys/socket.h>
+#endif
 
 static unsigned int bx_slirp_instances = 0;
 

--- a/bochs/iodev/network/eth_socket.cc
+++ b/bochs/iodev/network/eth_socket.cc
@@ -93,10 +93,10 @@ extern "C" {
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
-#include <net/ethernet.h>
 #include <net/if.h>
 #ifdef __linux__
 #include <linux/types.h>
+#include <net/ethernet.h>
 #endif
 #include <netdb.h>
 #define closesocket(s) close(s)


### PR DESCRIPTION
Add a few missing headers.

```
eth_slirp.cc:288:13: error: use of undeclared identifier 'AF_INET6'
  288 |   inet_pton(AF_INET6, "fec0::", &config.vprefix_addr6);
      |             ^~~~~~~~
eth_slirp.cc:571:21: error: use of undeclared identifier 'AF_INET6'
  571 |           inet_pton(AF_INET6, val, &config.vprefix_addr6);
      |                     ^~~~~~~~
eth_slirp.cc:780:27: error: use of undeclared identifier 'WIFEXITED'
  780 |         if (ret == -1 || !WIFEXITED(ret)) {
      |                           ^~~~~~~~~
eth_slirp.cc:783:20: error: use of undeclared identifier 'WEXITSTATUS'
  783 |         } else if (WEXITSTATUS(ret)) {
      |                    ^~~~~~~~~~~
eth_slirp.cc:785:27: error: use of undeclared identifier 'WEXITSTATUS'
  785 |                      cmd, WEXITSTATUS(ret));
      |                           ^~~~~~~~~~~
5 errors generated.
```
```
In file included from textconfig.cc:58:
../logio.h:66:62: error: unknown type name 'va_list'; did you mean '__va_list'?
   66 |   void fatal(int level, const char *prefix, const char *fmt, va_list ap, int exit_status);
      |                                                              ^~~~~~~
      |                                                              __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
  127 | typedef __builtin_va_list       __va_list;
      |                                 ^
In file included from textconfig.cc:58:
../logio.h:67:61: error: unknown type name 'va_list'; did you mean '__va_list'?
   67 |   void warn(int level, const char *prefix, const char *fmt, va_list ap);
      |                                                             ^~~~~~~
      |                                                             __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
  127 | typedef __builtin_va_list       __va_list;
      |                                 ^
In file included from textconfig.cc:58:
../logio.h:68:60: error: unknown type name 'va_list'; did you mean '__va_list'?
   68 |   void ask(int level, const char *prefix, const char *fmt, va_list ap);
      |                                                            ^~~~~~~
      |                                                            __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
  127 | typedef __builtin_va_list       __va_list;
      |                                 ^
In file included from textconfig.cc:58:
../logio.h:111:57: error: unknown type name 'va_list'; did you mean '__va_list'?
  111 |   void out(int level, const char *pre, const char *fmt, va_list ap);
      |                                                         ^~~~~~~
      |                                                         __va_list
/usr/include/machine/_types.h:127:27: note: '__va_list' declared here
  127 | typedef __builtin_va_list       __va_list;
      |                                 ^
4 errors generated.
```