### PR TITLE
Fix VDPPS floating-point exception ordering

### DIFF
--- a/bochs/cpu/avx/avx_pfp.cc
+++ b/bochs/cpu/avx/avx_pfp.cc
@@ -519,21 +519,22 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::VDPPS_VpsHpsWpsIbR(bxInstruction_c *i)
 
     // after multiplication: op1 = [AE, BF, CG, DH]
     xmm_mulps_mask(&op1.ymm128(n), &op2.ymm128(n), status, mask >> 4);
+    check_exceptionsSSE(softfloat_getExceptionFlags(&status));
 
     // shuffle op2 = [BF, AE, DH, CG]
     xmm_shufps(&op2.ymm128(n), &op1.ymm128(n), &op1.ymm128(n), 0xb1);
 
     // op2 = [(BF+AE), (AE+BF), (DH+CG), (CG+DH)]
     xmm_addps(&op2.ymm128(n), &op1.ymm128(n), status);
+    check_exceptionsSSE(softfloat_getExceptionFlags(&status));
 
     // shuffle op1 = [(DH+CG), (CG+DH), (BF+AE), (AE+BF)]
     xmm_shufpd(&op1.ymm128(n), &op2.ymm128(n), &op2.ymm128(n), 0x1);
 
     // op2 = [(BF+AE)+(DH+CG), (AE+BF)+(CG+DH), (DH+CG)+(BF+AE), (CG+DH)+(AE+BF)]
     xmm_addps_mask(&op2.ymm128(n), &op1.ymm128(n), status, mask);
+    check_exceptionsSSE(softfloat_getExceptionFlags(&status));
   }
-
-  check_exceptionsSSE(softfloat_getExceptionFlags(&status));
 
   BX_WRITE_YMM_REGZ_VLEN(i->dst(), op2, len);
 


### PR DESCRIPTION
## Problem

`VDPPS` must determine SIMD floating-point exceptions separately for
each multiply and add operation in execution order. An unmasked
exception must leave the destination unchanged.

The `VDPPS_VpsHpsWpsIbR` handler currently executes every arithmetic
stage for every 128-bit lane before calling `check_exceptionsSSE`.
This allows a later, higher-priority exception to replace an earlier
unmasked exception.

For example, consider `VDPPS xmm0,xmm1,xmm2,31h` with:

```text
bytes:         c4 e3 71 40 c2 31
xmm1:          { +max-finite, -max-finite, 0, 0 }
xmm2:          { +2.0,        +2.0,        0, 0 }
initial MXCSR: 0x00000f00

The multiplications produce overflow and precision exceptions. Overflow
is masked, but precision is unmasked, so execution must stop at that
stage. If execution continues, the later +Inf + -Inf addition produces
an invalid exception.

expected MXCSR at #XM:   0x00000f28  (overflow + precision)
The destination remains unchanged in both cases, but the exception flags
and reported cause are incorrect before this fix.

## Fix

Check exceptions after the multiplication and after each addition stage,
inside the loop over 128-bit lanes.

This matches the existing legacy DPPS implementation and ensures that
VEX.256 execution checks the lower 128-bit lane before proceeding to the
upper lane.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2A, section “DPPS—Dot Product of Packed Single Precision
Floating-Point Values,” specifies that exceptions are determined
separately for each multiply and add operation in execution order.
Unmasked exceptions leave the destination unchanged.

- Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2A (https://cdrdv2-public.intel.com/922480/253666-092-sdm-vol-2a.pdf)
- Intel® Software Developer Manuals download page (https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

The production Bochs build completed successfully:

make -C bochs -j2

An out-of-tree CPL3 guest probe executed the example above with
CR4.OSXMMEXCPT enabled.

After the fix, Bochs raises vector 19 with MXCSR 0x00000f28 and leaves
the destination XMM register unchanged, matching the native Intel
hardware result. Before the fix, Bochs reported MXCSR 0x0f01.

Additional out-of-tree probes compared legacy DPPS and the VEX.128 and
VEX.256 forms against native Intel hardware, covering normal arithmetic,
masked exceptions, and an unmasked exception in the upper 128-bit lane.
All result bits and MXCSR flags matched; the upper-lane fault also left
the complete YMM destination unchanged.