### PR TITLE
Fix 16-bit ENTER and LEAVE behavior in 64-bit mode

### DIFF
--- a/bochs/cpu/decoder/fetchdecode_opmap.h
+++ b/bochs/cpu/decoder/fetchdecode_opmap.h
@@ -1103,7 +1103,10 @@ static const Bit64u BxOpcodeTableC8_32[] = {
 };
 
 #if BX_SUPPORT_X86_64
-static const Bit64u BxOpcodeTableC8_64[] = { last_opcode(0, BX_IA_ENTER_Op64_IwIb) };
+static const Bit64u BxOpcodeTableC8_64[] = {
+  form_opcode(ATTR_OS32_64, BX_IA_ENTER_Op64_IwIb),
+  last_opcode(ATTR_OS16, BX_IA_ENTER_Op16_IwIb)
+};
 #endif
 
 // opcode C9

--- a/bochs/cpu/decoder/fetchdecode_opmap.h
+++ b/bochs/cpu/decoder/fetchdecode_opmap.h
@@ -1116,7 +1116,10 @@ static const Bit64u BxOpcodeTableC9_32[] = {
 };
 
 #if BX_SUPPORT_X86_64
-static const Bit64u BxOpcodeTableC9_64[] = { last_opcode(0, BX_IA_LEAVE_Op64) };
+static const Bit64u BxOpcodeTableC9_64[] = {
+  form_opcode(ATTR_OS32_64, BX_IA_LEAVE_Op64),
+  last_opcode(ATTR_OS16, BX_IA_LEAVE_Op16)
+};
 #endif
 
 // opcode CA

--- a/bochs/cpu/stack16.cc
+++ b/bochs/cpu/stack16.cc
@@ -264,10 +264,15 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::ENTER16_IwIb(bxInstruction_c *i)
 
 void BX_CPP_AttrRegparmN(1) BX_CPU_C::LEAVE16(bxInstruction_c *i)
 {
-  BX_ASSERT(BX_CPU_THIS_PTR cpu_mode != BX_MODE_LONG_64);
-
   Bit16u value16;
 
+#if BX_SUPPORT_X86_64
+  if (long64_mode()) {
+    value16 = stack_read_word(RBP);
+    RSP = RBP + 2;
+  }
+  else
+#endif
   if (BX_CPU_THIS_PTR sregs[BX_SEG_REG_SS].cache.u.segment.d_b) {
     value16 = stack_read_word(EBP);
     ESP = EBP + 2;

--- a/bochs/cpu/stack16.cc
+++ b/bochs/cpu/stack16.cc
@@ -186,6 +186,30 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::ENTER16_IwIb(bxInstruction_c *i)
   push_16(BP);
   Bit16u frame_ptr16 = SP;
 
+#if BX_SUPPORT_X86_64
+  if (long64_mode()) {
+    Bit64u rbp = RBP; // Use temp copy for case of exception.
+
+    if (level > 0) {
+      /* do level-1 times */
+      while (--level) {
+        rbp -= 2;
+        Bit16u temp16 = stack_read_word(rbp);
+        push_16(temp16);
+      }
+
+      /* push(frame pointer) */
+      push_16(frame_ptr16);
+    }
+
+    RSP -= imm16;
+
+    // ENTER finishes with memory write check on the final stack pointer
+    // the memory is touched but no write actually occurs
+    tickle_write_linear(BX_SEG_REG_SS, RSP, 2);
+  }
+  else
+#endif
   if (BX_CPU_THIS_PTR sregs[BX_SEG_REG_SS].cache.u.segment.d_b) {
     Bit32u ebp = EBP; // Use temp copy for case of exception.
 


### PR DESCRIPTION
## Problem

In 64-bit mode, `ENTER` and `LEAVE` default to 64-bit operation, while
a `66H` operand-size override selects 16-bit operation. A 32-bit form
cannot be encoded.

The long-mode C8 opcode table previously dispatched both prefixed and
unprefixed `ENTER` encodings to `ENTER64_IwIb`. Consequently:

```
bytes:        66 c8 00 00 00
instruction:  ENTER imm16=0, level=0
```

performed a qword push, decremented RSP by 8, and replaced the full RBP.
The required behavior is a word push, an RSP decrement of 2, and an
update of BP that preserves RBP[63:16].

While validating the `ENTER` fix, the companion `LEAVE` instruction was
found to have the same operand-size decoding problem. The long-mode C9
table dispatched `66 C9` to `LEAVE64`, causing a qword pop, an RSP
increment of 8, and replacement of the full RBP.

For `66 C9`, the processor must instead set RSP from the full RBP, pop a
word, advance RSP by 2, and update only BP.

## Fix

Split the long-mode C8 and C9 decoder entries by operand size:

- Unprefixed and effective REX.W forms continue to use the 64-bit
  `ENTER` and `LEAVE` handlers.
- Effective `66H` forms dispatch to the 16-bit handlers.

Extend `ENTER16_IwIb` for a 64-bit stack-address size. This path:

- Uses the full RSP for stack movement and allocation.
- Pushes 16-bit frame-pointer values.
- Uses full RBP addresses when copying nested frame pointers.
- Updates only BP, preserving RBP[63:16].
- Checks write access at the final 64-bit stack pointer.

Extend `LEAVE16` for a 64-bit stack-address size. This path:

- Uses the full RBP as the stack address.
- Pops a 16-bit frame pointer.
- Advances the full RSP by 2.
- Updates only BP, preserving RBP[63:16].

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2A, sections “ENTER—Make Stack Frame for Procedure Parameters”
and “LEAVE—High Level Procedure Exit,” specify that these instructions
default to 64-bit operation in 64-bit mode and support 16-bit operation
through the `66H` operand-size override.

For OperandSize=16 and StackSize=64, `ENTER` performs word pushes using
RSP and full RBP addresses. `LEAVE` copies the full RBP into RSP and
then pops a word into BP.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2A](https://cdrdv2-public.intel.com/922480/253666-092-sdm-vol-2a.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

Bochs built successfully with:

```sh
cd bochs
./configure \
  --enable-cpu-level=6 \
  --enable-x86-64 \
  --enable-avx \
  --enable-evex \
  --with-nogui
make -j4
```

A temporary 64-bit guest probe set RBP to
`0x112233445566a55a` and recorded the initial RSP as
`0x000000000004dfd8`. It then executed `66 C8 00 00 00` and
captured the resulting RSP, RBP, and data pushed onto the stack.

Before the fix:

```
before_rsp=0x000000000004dfd8
after_rsp=0x000000000004dfd0
after_rbp=0x000000000004dfd0
stack_qword=0x112233445566a55a
```

After the fix:

```
before_rsp=0x000000000004dfd8
after_rsp=0x000000000004dfd6
after_rbp=0x112233445566dfd6
pushed_word=0x000000000000a55a
```

The fixed result matches the behavior observed on native Intel
hardware.

A separate probe placed the qword `0x112233445566beef` at the address
held in RBP and executed `66 C9`. The fixed result was:

```
before_rbp=0x000000000004dfc8
after_rsp=0x000000000004dfca
after_rbp=0x000000000004beef
```

This matches native behavior: RSP advances from the original RBP by 2,
BP receives `0xbeef`, and the upper bits of RBP are preserved.

A paired test also executed `66H ENTER` with a 16-byte allocation,
followed by `66H LEAVE`:

```
before_rsp=0x000000000004dfd8
before_rbp=0x000000000004a55a
frame_rsp=0x000000000004dfc6
frame_rbp=0x000000000004dfd6
after_rsp=0x000000000004dfd8
after_rbp=0x000000000004a55a
```

The pair restored both RSP and RBP to their initial values.

Additional temporary guest cases verified that:

- Unprefixed and effective REX.W forms still perform 64-bit operation.
- Effective `66H` forms perform 16-bit operation.
- A `67H` address-size prefix does not change the 64-bit stack-address
  size.
- A 16-byte allocation with `66H ENTER` moves RSP by 18 bytes total.
- A nested 16-bit `ENTER` uses the full RBP address and copies
  word-sized frame pointers.

A clean CPU-level-6 build without `--enable-x86-64` also completed
successfully, confirming that the guarded long-mode paths do not affect
32-bit-only configurations.