### PR TITLE
Fix fast REP MOVSD/MOVSQ overlapping copies

### DIFF
--- a/bochs/cpu/faststring.cc
+++ b/bochs/cpu/faststring.cc
@@ -76,6 +76,14 @@ Bit32u BX_CPU_C::FastRepMOVSB(bx_address laddrSrc, bx_address laddrDst, Bit64u b
   // Check that native host access was not vetoed for that page
   if (!hostAddrDst) return 0;
 
+  // Each MOVS iteration must read a complete element before writing it.
+  // A forward byte copy cannot preserve this when the destination starts
+  // inside the current source element, so use the regular path instead.
+  bx_ptr_equiv_t hostSrc = (bx_ptr_equiv_t) hostAddrSrc;
+  bx_ptr_equiv_t hostDst = (bx_ptr_equiv_t) hostAddrDst;
+  if (hostDst > hostSrc && hostDst - hostSrc < granularity)
+    return 0;
+
   assert(! BX_CPU_THIS_PTR get_DF());
 
   // See how many bytes can fit in the rest of this page.


### PR DESCRIPTION
## Problem

Each `MOVSD` or `MOVSQ` iteration must read one complete source
dword or qword before writing it to the destination.

When repeat speedups are enabled, the dword and qword handlers call
`FastRepMOVSB` with a granularity of 4 or 8. The helper uses that
granularity to round the total byte count, but performs the transfer
one live byte at a time.

If the destination starts inside the current source element, an
earlier byte store can therefore alter a later byte load from the same
architectural element.

For example, with `RCX=1`, `DF=0`, source `S`, destination `S+1`, and
initial bytes:


11 22 33 44 00


`REP MOVSD` must first capture `11 22 33 44` and produce:


11 11 22 33 44


The fast path instead produces:


11 11 11 11 11


`REP MOVSQ` has the analogous problem for destination offsets one
through seven bytes into the source qword.

## Fix

Use a compact, low-risk fix: detect when the translated destination
host address starts inside the current source element and decline the
fast path for that case.

Returning zero lets the existing MOVSD/MOVSQ handler execute the
iteration using its dword or qword temporary, preserving the required
load-before-store behavior.

An alternative would be to rewrite the generic fast helper so that it
copies every element according to its requested granularity. That
would affect the complete fast-string transfer loop and require
additional consideration of alignment, host portability, and
iteration boundaries.

The targeted fallback avoids those broader changes. The existing
batched implementation remains unchanged for non-overlapping copies,
`MOVSB`, and overlaps that do not occur within one element. Only the
specific case that the byte loop cannot represent correctly uses the
regular path, retaining the speedup for normal workloads.

Using the translated host addresses also handles separate guest
linear mappings that alias the same backing memory.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2B, section “MOVS/MOVSB/MOVSW/MOVSD/MOVSQ—Move Data From
String to String,” defines each iteration as reading the source
operand and then writing that value to the destination before
advancing the indices.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2B](https://cdrdv2-public.intel.com/922481/253667-092-sdm-vol-2b.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

I built Bochs with `-O2` and:


--enable-cpu-level=6
--enable-x86-64
--enable-avx
--enable-evex
--with-nogui
--enable-repeat-speedups


The runtime banner confirmed that the affected implementation was
compiled and active:


RepeatSpeedups support: yes


A CPL3 guest probe tested one architectural element at a time, using
`RCX=1`, `DF=0`, source address `S`, and destination address `S+1`.
Both ranges were on the same writable page.

The byte values are arbitrary, distinguishable markers initialized by
the probe. They make it possible to see whether Bochs captures the
complete source element before starting the overlapping store.

For `REP MOVSD`, the probe initializes memory at `S` as:


Address:  S   S+1 S+2 S+3 S+4
Before:   11  22  33  44  00
Source:   [------ dword ------]
Dest:         [------ dword ------]


The source dword is `11 22 33 44`, and it must be captured before
being written at `S+1`. The expected memory bytes at `S` through
`S+4` are therefore:


Expected/native: 11 11 22 33 44
Before fix:      11 11 11 11 11
After fix:       11 11 22 33 44


Before the fix, the fast byte loop writes `11` to `S+1`, then reads
that modified byte as its next source byte. This repeats until `11`
has propagated across the destination.

For `REP MOVSQ`, the probe similarly initializes:


Address:  S  S+1 S+2 S+3 S+4 S+5 S+6 S+7 S+8
Before:   01  02  03  04  05  06  07  08  00
Source:   [-------------- qword --------------]
Dest:        [-------------- qword --------------]


The resulting bytes at `S` through `S+8` were:


Expected/native: 01 01 02 03 04 05 06 07 08
Before fix:      01 01 01 01 01 01 01 01 01
After fix:       01 01 02 03 04 05 06 07 08


Using `RCX=1` isolates the defect within a single dword or qword; the
result cannot be attributed to interactions between multiple REP
iterations.

The corrected results match native x86-64 execution, and the full
repeat-speedups build completed successfully.