### PR TITLE
Fix POPCNT instruction feature gate

### DIFF
--- a/bochs/cpu/decoder/ia_opcodes.def
+++ b/bochs/cpu/decoder/ia_opcodes.def
@@ -1409,10 +1409,10 @@ bx_define_opcode(BX_IA_MOVBE_MqGq, "movbe", "movbeq", &BX_CPU_C::MOVBE_MqGq, &BX
 #endif // BX_CPU_LEVEL >= 6
 
 // POPCNT instruction
-bx_define_opcode(BX_IA_POPCNT_GwEw, "popcnt", "popcntw", &BX_CPU_C::LOAD_Ew, &BX_CPU_C::POPCNT_GwEwR, BX_ISA_SSE4_2, OP_Gw, OP_Ew, OP_NONE, OP_NONE, 0)
-bx_define_opcode(BX_IA_POPCNT_GdEd, "popcnt", "popcntl", &BX_CPU_C::LOAD_Ed, &BX_CPU_C::POPCNT_GdEdR, BX_ISA_SSE4_2, OP_Gd, OP_Ed, OP_NONE, OP_NONE, 0)
+bx_define_opcode(BX_IA_POPCNT_GwEw, "popcnt", "popcntw", &BX_CPU_C::LOAD_Ew, &BX_CPU_C::POPCNT_GwEwR, BX_ISA_POPCNT, OP_Gw, OP_Ew, OP_NONE, OP_NONE, 0)
+bx_define_opcode(BX_IA_POPCNT_GdEd, "popcnt", "popcntl", &BX_CPU_C::LOAD_Ed, &BX_CPU_C::POPCNT_GdEdR, BX_ISA_POPCNT, OP_Gd, OP_Ed, OP_NONE, OP_NONE, 0)
 #if BX_SUPPORT_X86_64
-bx_define_opcode(BX_IA_POPCNT_GqEq, "popcnt", "popcntq", &BX_CPU_C::LOAD_Eq, &BX_CPU_C::POPCNT_GqEqR, BX_ISA_SSE4_2, OP_Gq, OP_Eq, OP_NONE, OP_NONE, 0)
+bx_define_opcode(BX_IA_POPCNT_GqEq, "popcnt", "popcntq", &BX_CPU_C::LOAD_Eq, &BX_CPU_C::POPCNT_GqEqR, BX_ISA_POPCNT, OP_Gq, OP_Eq, OP_NONE, OP_NONE, 0)
 #endif
 // POPCNT instruction
 


### PR DESCRIPTION
## Problem

`POPCNT` availability is enumerated independently through
CPUID.01H:ECX.POPCNT[23].

The three POPCNT opcode declarations currently use `BX_ISA_SSE4_2` as
their feature guard. As a result, decoder initialization disables POPCNT
when SSE4.2 is absent, even if the selected CPU model advertises POPCNT.

The built-in AMD Phenom X3 8650 Toliman model demonstrates this feature
combination: it enables `BX_ISA_POPCNT`, does not enable
`BX_ISA_SSE4_2`, and reports CPUID.01H:ECX.POPCNT=1. Before this fix,
executing POPCNT with that model dispatches `BxError` and raises #UD.

For example:

```text
CPU model:    phenom_8650_toliman
CPUID.1:ECX:  0x00802009
POPCNT:       1
SSE4.2:       0
bytes:        f3 0f b8 c0
instruction:  popcnt eax, eax
expected:     executes
before fix:   #UD
```

The inverse configuration can also incorrectly make POPCNT
decode-reachable when SSE4.2 is enabled but POPCNT is not advertised.

## Fix

Use `BX_ISA_POPCNT` as the feature guard for the 16-, 32-, and 64-bit
POPCNT opcode declarations.

This makes instruction decoding agree with the independently enumerated
POPCNT CPUID feature.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2B, section “POPCNT—Return the Count of Number of Bits Set to 1,”
specifies that software must check CPUID.01H:ECX.POPCNT[23]. If that bit
is clear, POPCNT raises #UD.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2B](https://cdrdv2-public.intel.com/922481/253667-092-sdm-vol-2b.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

Bochs was rebuilt successfully after rebuilding the affected decoder
object:

```sh
make -C bochs/cpu -B decoder/fetchdecode32.o
make -C bochs -j2
```

A temporary real-mode boot probe selected `phenom_8650_toliman`,
confirmed CPUID.01H:ECX.POPCNT=1 and SSE4.2=0, and executed 16-bit
POPCNT on `0xffff`:

```text
POPCNT=1 SSE4.2=0 POPCNT_AX=16 PASS
```