### PR TITLE
Fix PSHUFLW instruction feature gate

### DIFF
--- a/bochs/cpu/decoder/ia_opcodes.def
+++ b/bochs/cpu/decoder/ia_opcodes.def
@@ -1077,7 +1077,7 @@ bx_define_opcode(BX_IA_RSQRTSS_VssWss, "rsqrtss", "rsqrtss", &BX_CPU_C::LOAD_Wss
 bx_define_opcode(BX_IA_RCPPS_VpsWps, "rcpps", "rcpps", &BX_CPU_C::LOAD_Wdq, &BX_CPU_C::RCPPS_VpsWpsR, BX_ISA_SSE, OP_Vps, OP_Wps, OP_NONE, OP_NONE, BX_PREPARE_SSE)
 bx_define_opcode(BX_IA_RCPSS_VssWss, "rcpss", "rcpss", &BX_CPU_C::LOAD_Wss, &BX_CPU_C::RCPSS_VssWssR, BX_ISA_SSE, OP_Vss, OP_Wss, OP_NONE, OP_NONE, BX_PREPARE_SSE)
 bx_define_opcode(BX_IA_PSHUFW_PqQqIb, "pshufw", "pshufw", &BX_CPU_C::PSHUFW_PqQqIb, &BX_CPU_C::PSHUFW_PqQqIb, BX_ISA_SSE/* | BX_ISA_3DNOW */, OP_Pq, OP_Qq, OP_Ib, OP_NONE, BX_PREPARE_MMX)
-bx_define_opcode(BX_IA_PSHUFLW_VdqWdqIb, "pshuflw", "pshuflw", &BX_CPU_C::LOAD_Wdq, &BX_CPU_C::PSHUFLW_VdqWdqIbR, BX_ISA_SSE, OP_Vdq, OP_Wdq, OP_Ib, OP_NONE, BX_PREPARE_SSE)
+bx_define_opcode(BX_IA_PSHUFLW_VdqWdqIb, "pshuflw", "pshuflw", &BX_CPU_C::LOAD_Wdq, &BX_CPU_C::PSHUFLW_VdqWdqIbR, BX_ISA_SSE2, OP_Vdq, OP_Wdq, OP_Ib, OP_NONE, BX_PREPARE_SSE)
 bx_define_opcode(BX_IA_PINSRW_PqEwIb, "pinsrw", "pinsrw", &BX_CPU_C::PINSRW_PqEwIb, &BX_CPU_C::PINSRW_PqEwIb, BX_ISA_SSE/* | BX_ISA_3DNOW */, OP_Pq, OP_Ew, OP_Ib, OP_NONE, BX_PREPARE_MMX)
 bx_define_opcode(BX_IA_PEXTRW_GdNqIb, "pextrw", "pextrw", &BX_CPU_C::BxError, &BX_CPU_C::PEXTRW_GdNqIb, BX_ISA_SSE/* | BX_ISA_3DNOW */, OP_Gd, OP_Qq, OP_Ib, OP_NONE, BX_PREPARE_MMX)
 bx_define_opcode(BX_IA_SHUFPS_VpsWpsIb, "shufps", "shufps", &BX_CPU_C::LOAD_Wdq, &BX_CPU_C::SHUFPS_VpsWpsIbR, BX_ISA_SSE, OP_Vps, OP_Wps, OP_Ib, OP_NONE, BX_PREPARE_SSE)


### PR DESCRIPTION
## Problem

Legacy `PSHUFLW` is an SSE2 instruction whose availability is indicated
by CPUID.01H:EDX.SSE2[26].

Its opcode declaration currently uses `BX_ISA_SSE` as the feature guard.
As a result, decoder initialization enables `PSHUFLW` on processors that
support SSE but not SSE2.

The built-in Pentium III Katmai model demonstrates this feature
combination. It enables `BX_ISA_SSE`, does not enable `BX_ISA_SSE2`, and
reports SSE=1 and SSE2=0 through CPUID. Before this fix, it nevertheless
executes `PSHUFLW` instead of raising #UD.

For example:

```text
CPU model:    p3_katmai
CPUID.1:EDX:  0x0387f9ff
SSE:          1
SSE2:         0
bytes:        f2 0f 70 c0 00
instruction:  pshuflw xmm0, xmm0, 0
expected:     #UD
before fix:   executes
```

## Fix

Use `BX_ISA_SSE2` as the feature guard for the legacy `PSHUFLW` opcode
declaration.

This makes instruction decoding agree with the SSE2 feature reported by
the selected CPU model.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2B, section “PSHUFLW—Shuffle Packed Low Words,” identifies
`F2 0F 70 /r ib` as an SSE2 instruction and specifies #UD when
CPUID.01H:EDX.SSE2[26] is clear.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2B](https://cdrdv2-public.intel.com/922481/253667-092-sdm-vol-2b.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

Bochs was rebuilt successfully after rebuilding the affected decoder
object:

```sh
make -C bochs/cpu -B decoder/fetchdecode32.o
make -C bochs -j2
```

A temporary real-mode boot probe selected `p3_katmai`, confirmed
CPUID.01H:EDX.SSE=1 and SSE2=0, enabled SSE state use, and executed
`F2 0F 70 C0 00`.

Before the fix:

```text
SSE=1 SSE2=0 PSHUFLW=EXECUTED
```

After the fix:

```text
SSE=1 SSE2=0 PSHUFLW=#UD
```