### PR TITLE
Fix KSHIFTW behavior for a shift count of 15

### DIFF
--- a/bochs/cpu/avx/avx512_mask16.cc
+++ b/bochs/cpu/avx/avx512_mask16.cc
@@ -157,7 +157,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::KSHIFTLW_KGwKEwIbR(bxInstruction_c *i)
 #if BX_SUPPORT_EVEX
   unsigned count = i->Ib();
   Bit16u opmask = 0;
-  if (count < 15)
+  if (count < 16)
     opmask = BX_READ_16BIT_OPMASK(i->src()) << count;
 
   BX_WRITE_OPMASK(i->dst(), opmask);
@@ -171,7 +171,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::KSHIFTRW_KGwKEwIbR(bxInstruction_c *i)
 #if BX_SUPPORT_EVEX
   unsigned count = i->Ib();
   Bit16u opmask = 0;
-  if (count < 15)
+  if (count < 16)
     opmask = BX_READ_16BIT_OPMASK(i->src()) >> count;
 
   BX_WRITE_OPMASK(i->dst(), opmask);


### PR DESCRIPTION
## Problem

The 16-bit `KSHIFTLW` and `KSHIFTRW` forms treat an immediate count of
15 as out of range.

The architectural operation shifts the 16-bit source for counts through
15 and clears the destination only when the count is greater than 15.
The Bochs handlers currently perform the shift only when `count < 15`,
so the maximum valid count incorrectly produces zero.

For example:

```text
source k1:   0x0001
bytes:       c4 e3 f9 32 d1 0f
instruction: kshiftlw k2, k1, 15
expected:    k2 = 0x8000
before fix:  k2 = 0x0000
```

Similarly:

```text
source k1:   0x8000
bytes:       c4 e3 f9 30 d1 0f
instruction: kshiftrw k2, k1, 15
expected:    k2 = 0x0001
before fix:  k2 = 0x0000
```

## Fix

Use `count < 16` for the word-form `KSHIFTLW` and `KSHIFTRW`
handlers.

This includes the valid count of 15 while retaining a zero result for
counts greater than 15.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2B, sections “KSHIFTLW/KSHIFTLB/KSHIFTLQ/KSHIFTLD—Shift Left
Mask Registers” and
“KSHIFTRW/KSHIFTRB/KSHIFTRQ/KSHIFTLD—Shift Right Mask Registers,”
specifies that the 16-bit forms perform the shift when the count is less
than or equal to 15 and clear the destination otherwise.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2B](https://cdrdv2-public.intel.com/922481/253667-092-sdm-vol-2b.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

Bochs was rebuilt successfully:

```sh
make -C bochs -j2
```

A temporary protected-mode boot probe selected `corei7_skylake_x`,
enabled opmask and AVX-512 state in XCR0, and tested counts 14, 15, and
16 for both instructions.

Before the fix:

```text
L14/L15/L16=4000/0000/0000
R14/R15/R16=0002/0000/0000
```

After the fix:

```text
L14/L15/L16=4000/8000/0000
R14/R15/R16=0002/0001/0000
```

The neighboring counts remain unchanged: count 14 shifts normally and
count 16 produces zero.