### PR TITLE
Fix VEX.128 crypto instruction feature gates

### DIFF
--- a/bochs/cpu/decoder/ia_opcodes.def
+++ b/bochs/cpu/decoder/ia_opcodes.def
@@ -2248,13 +2248,13 @@ bx_define_opcode(BX_IA_V128_VPCMPESTRI_VdqWdqIb, "vpcmpestri", "vpcmpestri", &BX
 bx_define_opcode(BX_IA_V128_VPCMPISTRM_VdqWdqIb, "vpcmpistrm", "vpcmpistrm", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::PCMPISTRM_VdqWdqIbR, BX_ISA_AVX, OP_Vdq, OP_Wdq, OP_Ib, OP_NONE, BX_PREPARE_AVX)
 bx_define_opcode(BX_IA_V128_VPCMPISTRI_VdqWdqIb, "vpcmpistri", "vpcmpistri", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::PCMPISTRI_VdqWdqIbR, BX_ISA_AVX, OP_Vdq, OP_Wdq, OP_Ib, OP_NONE, BX_PREPARE_AVX)
 
-bx_define_opcode(BX_IA_V128_VAESIMC_VdqWdq, "vaesimc", "vaesimc", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::AESIMC_VdqWdqR, BX_ISA_AVX, OP_Vdq, OP_Wdq, OP_NONE, OP_NONE, BX_PREPARE_AVX)
-bx_define_opcode(BX_IA_V128_VAESKEYGENASSIST_VdqWdqIb, "vaeskeygenassist", "vaeskeygenassist", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::AESKEYGENASSIST_VdqWdqIbR, BX_ISA_AVX, OP_Vdq, OP_Wdq, OP_Ib, OP_NONE, BX_PREPARE_AVX)
-bx_define_opcode(BX_IA_V128_VAESENC_VdqHdqWdq, "vaesenc", "vaesenc", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESENC_VdqHdqWdqR, BX_ISA_AVX, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
-bx_define_opcode(BX_IA_V128_VAESENCLAST_VdqHdqWdq, "vaesenclast", "vaesenclast", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESENCLAST_VdqHdqWdqR, BX_ISA_AVX, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
-bx_define_opcode(BX_IA_V128_VAESDEC_VdqHdqWdq, "vaesdec", "vaesdec", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESDEC_VdqHdqWdqR, BX_ISA_AVX, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
-bx_define_opcode(BX_IA_V128_VAESDECLAST_VdqHdqWdq, "vaesdeclast", "vaesdeclast", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESDECLAST_VdqHdqWdqR, BX_ISA_AVX, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
-bx_define_opcode(BX_IA_V128_VPCLMULQDQ_VdqHdqWdqIb, "vpclmulqdq", "vpclmulqdq", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VPCLMULQDQ_VdqHdqWdqIbR, BX_ISA_AVX, OP_Vdq, OP_Hdq, OP_Wdq, OP_Ib, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VAESIMC_VdqWdq, "vaesimc", "vaesimc", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::AESIMC_VdqWdqR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Wdq, OP_NONE, OP_NONE, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VAESKEYGENASSIST_VdqWdqIb, "vaeskeygenassist", "vaeskeygenassist", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::AESKEYGENASSIST_VdqWdqIbR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Wdq, OP_Ib, OP_NONE, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VAESENC_VdqHdqWdq, "vaesenc", "vaesenc", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESENC_VdqHdqWdqR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VAESENCLAST_VdqHdqWdq, "vaesenclast", "vaesenclast", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESENCLAST_VdqHdqWdqR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VAESDEC_VdqHdqWdq, "vaesdec", "vaesdec", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESDEC_VdqHdqWdqR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VAESDECLAST_VdqHdqWdq, "vaesdeclast", "vaesdeclast", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VAESDECLAST_VdqHdqWdqR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)
+bx_define_opcode(BX_IA_V128_VPCLMULQDQ_VdqHdqWdqIb, "vpclmulqdq", "vpclmulqdq", &BX_CPU_C::LOADU_Wdq, &BX_CPU_C::VPCLMULQDQ_VdqHdqWdqIbR, BX_ISA_AES_PCLMULQDQ, OP_Vdq, OP_Hdq, OP_Wdq, OP_Ib, BX_PREPARE_AVX)
 
 // VAES extensions
 bx_define_opcode(BX_IA_V256_VAESENC_VdqHdqWdq, "vaesenc", "vaesenc", &BX_CPU_C::LOAD_Vector, &BX_CPU_C::VAESENC_VdqHdqWdqR, BX_ISA_VAES_VPCLMULQDQ, OP_Vdq, OP_Hdq, OP_Wdq, OP_NONE, BX_PREPARE_AVX)


### PR DESCRIPTION
## Problem

The VEX.128 forms of the AES and carry-less multiplication instructions
require the corresponding legacy crypto feature in addition to AVX.

Specifically, the VEX.128 AES instructions require
CPUID.01H:ECX.AES[25] and AVX, while VEX.128 `VPCLMULQDQ` requires
CPUID.01H:ECX.PCLMULQDQ[1] and AVX.

Their seven Bochs opcode declarations currently use only `BX_ISA_AVX`
as their feature guard. Decoder initialization therefore retains the
execution handlers when AVX is available but AES and PCLMULQDQ are not
advertised.

For example, with `corei7_skylake_x` and
`exclude_features=aes_pclmulqdq`:

```text
CPUID.1:ECX:  0x7dfaf39d
AES:          0
PCLMULQDQ:    0
AVX:          1
OSXSAVE:      1
XCR0:         0xe7
mode:         long mode, CPL3

c4 e2 71 de c2       vaesdec xmm0, xmm1, xmm2
c4 e2 71 df c2       vaesdeclast xmm0, xmm1, xmm2
c4 e2 71 dc c2       vaesenc xmm0, xmm1, xmm2
c4 e2 71 dd c2       vaesenclast xmm0, xmm1, xmm2
c4 e2 79 db c1       vaesimc xmm0, xmm1
c4 e3 79 df c1 01    vaeskeygenassist xmm0, xmm1, 1
c4 e3 71 44 c2 00    vpclmulqdq xmm0, xmm1, xmm2, 0

expected: #UD for all seven instructions
before:   all seven instructions execute
```

The newer VAES and VPCLMULQDQ feature is used for wider vector forms;
it does not replace the AES or PCLMULQDQ requirement for these VEX.128
encodings.

## Fix

Use `BX_ISA_AES_PCLMULQDQ` as the feature guard for the six VEX.128 AES
declarations and the VEX.128 `VPCLMULQDQ` declaration, while retaining
their existing `BX_PREPARE_AVX` checks.

Bochs models AES and PCLMULQDQ together under this extension and already
uses it for the corresponding legacy instruction declarations. The
feature guard now checks crypto availability, while `BX_PREPARE_AVX`
continues to enforce AVX and its architectural state requirements.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2, specifies AES together with AVX for the VEX.128 AES encodings
and PCLMULQDQ together with AVX for the VEX.128 `VPCLMULQDQ` encoding.
The instructions raise #UD when their required CPUID feature is absent.

- [Intel® 64 and IA-32 Architectures Software Developer’s Manual](https://cdrdv2-public.intel.com/843950/325462-sdm-vol-1-2abcd-3abcd-4.pdf)
- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

The affected 32- and 64-bit decoder objects were forcibly rebuilt,
followed by a successful full Bochs build:

```sh
make -C bochs/cpu -B decoder/fetchdecode32.o decoder/fetchdecode64.o
make -C bochs -j2
```

A temporary long-mode CPL3 probe tested all seven VEX.128 encodings
under three feature configurations.

With AVX enabled and `aes_pclmulqdq` excluded:

```text
CPUID.1:ECX=0x7dfaf39d
XCR0=0xe7

VAESDEC=#UD
VAESDECLAST=#UD
VAESENC=#UD
VAESENCLAST=#UD
VAESIMC=#UD
VAESKEYGENASSIST=#UD
VPCLMULQDQ=#UD
BV:DONE status=pass
```

With AVX, AES, and PCLMULQDQ enabled, all seven instructions continued
to execute:

```text
CPUID.1:ECX=0x7ffaf39f
XCR0=0xe7

VAESDEC=EXECUTED
VAESDECLAST=EXECUTED
VAESENC=EXECUTED
VAESENCLAST=EXECUTED
VAESIMC=EXECUTED
VAESKEYGENASSIST=EXECUTED
VPCLMULQDQ=EXECUTED
BV:DONE status=pass
```

Finally, a control test verified that the fix does not make these VEX
encodings available on processors without AVX.

AES and PCLMULQDQ were enabled, but AVX was disabled. XCR0 contained
only x87 and SSE state (`0x3`), with no AVX state enabled:

```text
AES:          1
PCLMULQDQ:    1
AVX:          0
XCR0:         0x3
```

All seven instructions correctly raised #UD:

```text
VAESDEC=#UD
VAESDECLAST=#UD
VAESENC=#UD
VAESENCLAST=#UD
VAESIMC=#UD
VAESKEYGENASSIST=#UD
VPCLMULQDQ=#UD
BV:DONE status=pass
```

This confirms that `BX_ISA_AES_PCLMULQDQ` enforces crypto availability,
while the retained `BX_PREPARE_AVX` checks continue to enforce the
independent AVX and AVX-state requirements.