### PR TITLE
Fix full-width VPCOMPRESS byte and word masks

### DIFF
--- a/bochs/cpu/avx/avx512.cc
+++ b/bochs/cpu/avx/avx512.cc
@@ -1836,7 +1836,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::VPCOMPRESSB_MASK_WdqVdq(bxInstruction_c *i
     }
   }
 
-  Bit64u writemask = (BX_CONST64(1) << k) - 1;
+  Bit64u writemask = (k == 64) ? BX_CONST64(0xFFFFFFFFFFFFFFFF) : (BX_CONST64(1) << k) - 1;
 
   if (i->modC0()) {
     avx512_write_regb_masked(i, &result, len, writemask);
@@ -1865,7 +1865,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::VPCOMPRESSW_MASK_WdqVdq(bxInstruction_c *i
     }
   }
 
-  Bit32u writemask = (1 << k) - 1;
+  Bit32u writemask = (k == 32) ? 0xFFFFFFFF : (1 << k) - 1;
 
   if (i->modC0()) {
     avx512_write_regw_masked(i, &result, len, writemask);


### PR DESCRIPTION
## Problem

`VPCOMPRESSB` and `VPCOMPRESSW` construct a dense write mask after
packing the selected source elements:

```cpp
Bit64u writemask = (BX_CONST64(1) << k) - 1;
Bit32u writemask = (1 << k) - 1;
```

For an EVEX.512 instruction with every mask bit set, `k` reaches 64
for byte elements and 32 for word elements. The resulting C++ shifts
use a shift count equal to the width of the operand, which is undefined
behavior.

On the tested build, both expressions produced a zero write mask. The
shared instruction handlers consequently suppressed the complete
register write or memory store instead of writing all selected
elements.

## Fix

Use an all-ones write mask when `k` reaches the full element count:

- `0xffffffffffffffff` for 64 byte elements
- `0xffffffff` for 32 word elements

Retain the existing shift expression for smaller element counts. The
same handlers implement register and memory destinations, so this
corrects both forms.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual,
Volume 2, sections “VPCOMPRESSB/VPCOMPRESSW—Store Sparse Packed
Byte/Word Integer Values Into Dense Memory/Register,” specify that
source elements selected by the writemask are copied consecutively
into the low elements of the destination.

For an EVEX.512 operation with every writemask bit set, all 64 byte
elements or all 32 word elements are selected. The instruction must
therefore write the complete 512-bit result.

- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

A standalone 64-bit CPL3 guest exercised the instructions on the Bochs
`tigerlake` CPU model with AVX-512 state enabled (`XCR0=0xe7`).

Each test initialized its destination with a distinguishable sentinel.
The full-width cases compared all 64 result bytes with the source. The
boundary controls selected 63 bytes or 31 words and additionally
verified that the unselected final destination element retained its
sentinel value.

| Instruction | Destination | Selected elements | Before | After |
|---|---|---:|---:|---:|
| `VPCOMPRESSB` | register | 64 | FAIL | PASS |
| `VPCOMPRESSB` | register | 63 | PASS | PASS |
| `VPCOMPRESSB` | memory | 64 | FAIL | PASS |
| `VPCOMPRESSB` | memory | 63 | PASS | PASS |
| `VPCOMPRESSW` | register | 32 | FAIL | PASS |
| `VPCOMPRESSW` | register | 31 | PASS | PASS |
| `VPCOMPRESSW` | memory | 32 | FAIL | PASS |
| `VPCOMPRESSW` | memory | 31 | PASS | PASS |

UBSan also identified the two affected expressions as shifts with
exponents 64 and 32, respectively.

The patched tree was rebuilt successfully with `make -j2`.
