### PR TITLE
Fix VPEXPAND byte and word memory load masks

### DIFF
--- a/bochs/cpu/avx/avx512.cc
+++ b/bochs/cpu/avx/avx512.cc
@@ -1608,7 +1608,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::VPEXPANDB_MASK_VdqWdqM(bxInstruction_c *i)
     // the EXPAND is going to read an element for each bit set to '1 in the opmask
     // and place it into the element corresponding to the opmask bit in the result
     // so it will read popcntq(opmask) bits from the source
-    Bit64u load_mask = (opmask == BX_CONST64(0xFFFFFFFFFFFFFFFF)) ? opmask : (1 << popcntq(opmask)) - 1;
+    Bit64u load_mask = (opmask == BX_CONST64(0xFFFFFFFFFFFFFFFF)) ? opmask : (BX_CONST64(1) << popcntq(opmask)) - 1;
     avx_masked_load8(i, BX_CPU_RESOLVE_ADDR(i), &op, load_mask); // read only popcntq(opmask) elements from the memory
 
     for (unsigned n = 0, k = 0; n < BYTE_ELEMENTS(len); n++, opmask >>= 1) {
@@ -1665,7 +1665,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::VPEXPANDW_MASK_VdqWdqM(bxInstruction_c *i)
     // the EXPAND is going to read an element for each bit set to '1 in the opmask
     // and place it into the element corresponding to the opmask bit in the result
     // so it will read popcntd(opmask) bits from the source
-    Bit32u load_mask = (1 << popcntd(opmask)) - 1;
+    Bit32u load_mask = (opmask == 0xffffffff) ? opmask : (Bit32u(1) << popcntd(opmask)) - 1;
     avx_masked_load16(i, BX_CPU_RESOLVE_ADDR(i), &op, load_mask); // read only popcntd(opmask) elements from the memory
 
     for (unsigned n = 0, k = 0; n < WORD_ELEMENTS(len); n++, opmask >>= 1) {


### PR DESCRIPTION
## Problem

The memory-source handlers for `VPEXPANDB` and `VPEXPANDW` build a
dense load mask from the number of enabled destination elements:

```cpp
Bit64u load_mask = (opmask == BX_CONST64(0xFFFFFFFFFFFFFFFF)) ? opmask : (1 << popcntq(opmask)) - 1;
Bit32u load_mask = (1 << popcntd(opmask)) - 1;
```

Both shifts begin with the signed 32-bit integer literal `1`. For
`VPEXPANDB`, a population count of 31 shifts into the sign bit, while
counts from 32 through 63 use a shift count outside the type's width.
For `VPEXPANDW`, count 31 similarly shifts into the sign bit and count
32 uses an out-of-range shift. These operations have undefined behavior
in C++.

In the tested optimized build, `VPEXPANDB` produced incorrect results
for counts 32 through 63, including an EVEX.256 operation selecting all
32 byte elements. `VPEXPANDW` produced an incorrect result when all 32
word elements were selected by an EVEX.512 operation.

Only the masked memory-source handlers construct these dense load masks.
The register-source handlers are unaffected.

## Fix

Construct the byte load mask with `BX_CONST64(1)`, making shifts through
count 63 well-defined while retaining the existing special case for all
64 byte elements.

For the word load mask, handle all 32 elements with an explicit all-ones
mask and use `Bit32u(1)` for smaller counts. This also makes the
count-31 boundary unsigned and well-defined.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer's Manual,
Volume 2, section “VPEXPANDB/VPEXPANDW—Load Sparse Packed Byte/Word
Integer Values from Dense Memory/Register,” specifies that consecutive
elements from the dense source are copied to destination positions
selected by the writemask.

Consequently, a memory-source operation must load one consecutive source
element for each enabled destination element. The internal dense load
mask must therefore contain exactly `popcount(k)` low set bits, including
the full 32-byte and 32-word cases.

- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

A standalone 64-bit CPL3 guest exercised the memory-source forms on the
Bochs `tigerlake` CPU model with AVX-512 state enabled (`XCR0=0xe7`).
Every test used ordinary mapped memory containing distinctive nonzero
elements and initialized the destination with nonzero merge sentinels.

The count-31 cases check the signed-shift boundary. The 64-byte case
checks the existing full-width special case. The remaining cases cover
the observed incorrect ranges and both applicable vector lengths at the
32-byte boundary.

| Instruction | Vector length | Active elements / mask shape | Before | After |
|---|---:|---|---:|---:|
| `VPEXPANDB` | 512 | 31 low elements | PASS | PASS |
| `VPEXPANDB` | 256 | 32 elements (all) | FAIL | PASS |
| `VPEXPANDB` | 512 | 32 sparse elements | FAIL | PASS |
| `VPEXPANDB` | 512 | 33 sparse elements | FAIL | PASS |
| `VPEXPANDB` | 512 | 63 sparse elements | FAIL | PASS |
| `VPEXPANDB` | 512 | 64 elements (all) | PASS | PASS |
| `VPEXPANDW` | 512 | 31 sparse elements | PASS | PASS |
| `VPEXPANDW` | 512 | 32 elements (all) | FAIL | PASS |

The source file used by the patched test build exactly matches the
committed source, and the patched tree builds successfully with
`make -j2`. `git diff --check` also passes.

The validation used mapped memory and confirms the result correction. It
did not separately test page-fault behavior.
