### PR TITLE
Fix upper ZMM clearing for EVEX.512 VGATHERQPS and VPGATHERQD

### DIFF
--- a/bochs/cpu/avx/gather.cc
+++ b/bochs/cpu/avx/gather.cc
@@ -334,7 +334,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::VGATHERQPS_MASK_VpsVSib(bxInstruction_c *i
 
   // ensure correct upper part clearing of the destination register
   if (len == BX_VL128) dest->vmm64u(1) = 0;
-  else len--;
+  else len >>= 1;
 
   BX_WRITE_OPMASK(i->opmask(), 0);
   BX_CLEAR_AVX_REGZ(i->dst(), len);


### PR DESCRIPTION
## Problem

The shared handler for `VGATHERQPS` and `VPGATHERQD` uses the encoded
vector-length value to clear the portion of the architectural destination
above its logical dword result:

```cpp
if (len == BX_VL128) dest->vmm64u(1) = 0;
else len--;

BX_CLEAR_AVX_REGZ(i->dst(), len);
```

The vector-length constants are encoded as `BX_VL128 = 1`,
`BX_VL256 = 2`, and `BX_VL512 = 4`. Decrementing the 256-bit value maps
it to `BX_VL128`, but decrementing the 512-bit value produces `3`.
`BX_CLEAR_AVX_REGZ` recognizes only the 128- and 256-bit constants, so
it performs no clearing for that value.

Consequently, EVEX.512 `VGATHERQPS` and `VPGATHERQD` leave destination
bits 511:256 unchanged after successful completion. These instructions
produce eight dword results from eight qword indices, so their logical
result occupies only the low 256 bits of the ZMM destination.

## Fix

Shift the vector-length value right by one instead of decrementing it.
This maps each index-vector length to the corresponding dword-result
length:

- `BX_VL256` becomes `BX_VL128`
- `BX_VL512` becomes `BX_VL256`

The existing special handling for `BX_VL128` remains unchanged. The
shared handler therefore clears the correct upper destination portion
for both instruction families and all supported vector lengths.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer's Manual,
Volume 2, sections “VGATHERQPS—Gather Packed Single Precision
Floating-Point Values Using Signed Qword Indices” and
“VPGATHERQD—Gather Packed Dword Values Using Signed Qword Indices,”
specifies `DEST[MAXVL-1:VL/2] := 0` for these forms.

For an EVEX.512 operation, the eight gathered dwords occupy destination
bits 255:0 and bits 511:256 must be zero after successful completion.

- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

A standalone 64-bit CPL3 guest exercised the gather forms on the Bochs
`tigerlake` CPU model with AVX-512 state enabled (`XCR0=0xe7`).
Destinations were initialized with distinctive nonzero values so that
retained upper bits were directly observable.

The zero-mask cases complete without reading memory and isolate the
architectural merge and upper-clearing behavior. The active-mask
`VPGATHERQD` case used ordinary mapped memory, verified the gathered
dwords and preserved inactive low lanes, and then checked that bits
511:256 were cleared.

| Instruction | Vector length | Mask | Before | After |
|---|---:|---:|---:|---:|
| `VPGATHERQD` | 512 | zero | FAIL | PASS |
| `VPGATHERQD` | 512 | active (`0xa5`) | FAIL | PASS |
| `VGATHERQPS` | 512 | zero | FAIL | PASS |
| `VPGATHERQD` | 256 | zero | PASS | PASS |
| `VPGATHERQD` | 128 | zero | PASS | PASS |
| `VPGATHERQQ` | 512 | zero | PASS | PASS |

The 128- and 256-bit `VPGATHERQD` cases verify the neighboring logical
result widths. The 512-bit `VPGATHERQQ` control verifies that a gather
whose qword results fill the complete ZMM destination remains unchanged.

The source file used by the patched test build exactly matches the
committed source. The patched tree builds successfully with `make -j2`,
and `git diff --check` passes.
