### PR TITLE
Fix equal-magnitude MIN_ABS/MAX_ABS selection in VRANGE instructions

### DIFF
--- a/bochs/cpu/softfloat3e/f32_range.cc
+++ b/bochs/cpu/softfloat3e/f32_range.cc
@@ -96,7 +96,8 @@ float32 f32_range(float32 a, float32 b, bool is_max, bool is_abs, int sign_ctrl,
     else if (aIsNaN) {
         z = b;
     }
-    else if (signA != signB && ! is_abs) {
+    else if (signA != signB && (! is_abs ||
+             ((a & ~0x80000000) == (b & ~0x80000000)))) {
         if (! is_max) {
             z = signA ? a : b;
         } else {

--- a/bochs/cpu/softfloat3e/f64_range.cc
+++ b/bochs/cpu/softfloat3e/f64_range.cc
@@ -96,7 +96,9 @@ float64 f64_range(float64 a, float64 b, bool is_max, bool is_abs, int sign_ctrl,
     else if (aIsNaN) {
         z = b;
     }
-    else if (signA != signB && ! is_abs) {
+    else if (signA != signB && (! is_abs ||
+             ((a & ~UINT64_C(0x8000000000000000)) ==
+              (b & ~UINT64_C(0x8000000000000000))))) {
         if (! is_max) {
             z = signA ? a : b;
         } else {


### PR DESCRIPTION
## Problem

The shared `f32_range` and `f64_range` helpers implement the `MIN_ABS` and
`MAX_ABS` operations used by `VRANGEPD`, `VRANGEPS`, `VRANGESD`, and
`VRANGESS`.

For absolute-value comparisons, the helpers clear both operand signs and use
a strict less-than comparison. When the operands have equal magnitudes but
opposite signs, equality therefore falls through to a source-order-dependent
choice: `MIN_ABS` selects SRC2 and `MAX_ABS` selects SRC1.

Consequently, one source order returns the positive operand for `MIN_ABS` and
the negative operand for `MAX_ABS`. This also affects `-0.0`/`+0.0` ties.

## Fix

Extend the existing opposite-sign selection path to cover equal-magnitude
absolute comparisons. The helpers compare magnitudes by clearing the IEEE-754
sign bit from each operand before testing for equality.

This follows the existing Bochs SoftFloat convention used by the float32,
float64, and float16 MINMAX helpers, as well as by the surrounding RANGE
code.

When the magnitudes are equal and the signs differ, the existing selection
logic then chooses the negative operand for MIN_ABS and the positive operand
for MAX_ABS, independent of source order. NaN handling and DAZ normalization
remain unchanged and occur before this selection.

## Architectural reference

The Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 2,
sections “VRANGEPD—Range Restriction Calculation for Packed Pairs of Float64
Values,” “VRANGEPS—Range Restriction Calculation for Packed Pairs of Float32
Values,” “VRANGESD—Range Restriction Calculation From a Pair of Scalar
Float64 Values,” and “VRANGESS—Range Restriction Calculation From a Pair of
Scalar Float32 Values,” define the range operations in Tables 5-22 and 5-23.

For equal-magnitude operands with opposite signs, those tables require
`MIN_ABS` to select the negative operand and `MAX_ABS` to select the positive
operand.

- [Intel® Software Developer Manuals download page](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)

## Validation

A standalone 64-bit CPL3 guest exercised the four instructions on the Bochs
`tigerlake` CPU model with AVX-512 state enabled (`XCR0=0xe7`). The tie tests
used both source orders for `-1.0`/`+1.0` and `-0.0`/`+0.0`, with sign control
set to preserve the selected operand’s sign.

| Instruction | Operations and tie inputs | Before | After |
|---|---|---:|---:|
| `VRANGEPD` | `MIN_ABS`/`MAX_ABS`, `±1.0` and `±0.0`, both orders | FAIL | PASS |
| `VRANGEPS` | `MIN_ABS`/`MAX_ABS`, `±1.0` and `±0.0`, both orders | FAIL | PASS |
| `VRANGESD` | `MIN_ABS`/`MAX_ABS`, `±1.0` and `±0.0`, both orders | FAIL | PASS |
| `VRANGESS` | `MIN_ABS`/`MAX_ABS`, `±1.0` and `±0.0`, both orders | FAIL | PASS |

Additional controls passed after the change:

- unequal-magnitude `MIN_ABS` and `MAX_ABS` inputs;
- immediate `0x02` source-1 sign control;
- packed merge masking;
- scalar active, merge-masked, and zero-masked forms;
- scalar upper-element preservation and ZMM upper-bit clearing; and
- quiet NaN, signaling NaN, DAZ, denormal-input, and exception-flag helper
  checks for both float32 and float64.

The patched tree was rebuilt successfully with `make -j2`.
