### PR TITLE
Initialization of Root Directory

### DIFF
--- a/bochs/iodev/hdimage/vvfat.cc
+++ b/bochs/iodev/hdimage/vvfat.cc
@@ -759,9 +759,8 @@ int vvfat_image_t::read_directory(int mapping_index)
   // actually read the directory, and allocate the mappings
   while ((entry=readdir(dir))) {
     if ((first_cluster == 0) && (directory.next >= (Bit16u)(root_entries - 1))) {
-      BX_ERROR(("Too many entries in root directory, using only %d", count));
-      closedir(dir);
-      return -2;
+      BX_PANIC(("Too many entries in root directory, using only %d", count));
+      break;
     }
     unsigned int length = strlen(dirname) + 2 + strlen(entry->d_name);
     char* buffer;
@@ -885,9 +884,8 @@ int vvfat_image_t::read_directory(int mapping_index)
   // actually read the directory, and allocate the mappings
   do {
     if ((first_cluster == 0) && (directory.next >= (Bit16u)(root_entries - 1))) {
-      BX_ERROR(("Too many entries in root directory, using only %d", count));
-      FindClose(hFind);
-      return -2;
+      BX_PANIC(("Too many entries in root directory, using only %d", count));
+      break;
     }
     unsigned int length = lstrlen(dirname) + 2 + lstrlen(finddata.cFileName);
     char* buffer;

--- a/bochs/iodev/hdimage/vvfat.cc
+++ b/bochs/iodev/hdimage/vvfat.cc
@@ -759,7 +759,7 @@ int vvfat_image_t::read_directory(int mapping_index)
   // actually read the directory, and allocate the mappings
   while ((entry=readdir(dir))) {
     if ((first_cluster == 0) && (directory.next >= (Bit16u)(root_entries - 1))) {
-      BX_PANIC(("Too many entries in root directory, using only %d", count));
+      BX_WARN(("Too many entries in root directory, using only %d", count));
       break;
     }
     unsigned int length = strlen(dirname) + 2 + strlen(entry->d_name);
@@ -884,7 +884,7 @@ int vvfat_image_t::read_directory(int mapping_index)
   // actually read the directory, and allocate the mappings
   do {
     if ((first_cluster == 0) && (directory.next >= (Bit16u)(root_entries - 1))) {
-      BX_PANIC(("Too many entries in root directory, using only %d", count));
+      BX_WARN(("Too many entries in root directory, using only %d", count));
       break;
     }
     unsigned int length = lstrlen(dirname) + 2 + lstrlen(finddata.cFileName);


### PR DESCRIPTION
When the initialization of the root directory exceeds the size given, the code should stop adding files and continue as normal instead of returning to the caller since the root directory must still be mapped.

The current code will crash Bochs. This PR simply stops adding files and continues as if no error was found.

The BX_PANIC is to inform the user that it stopped. Continuing after the PANIC has no ill effect on the simulation.
If we leave it as BX_ERROR, the user might wonder why all files are not available, unless they read the log file.

To reproduce this error, create a floppy using vvfat.

`floppya: 1_44=vvfat:vvfat, status=inserted`

Then using the code from a previous PR:
```
#include <stdio.h>

int main(int argc, char **argv)
{
  char fn[18];
  FILE *fd;

  for (int i = 0; i <= 100; i++) {
    sprintf(fn, "LongFilename %03d.txt", i);
    fd = fopen(fn, "w");
    fprintf(fd, "Test %03d\r\n", i);
    fclose(fd);
    fprintf(stderr, "%s\n", fn);
  }
  return 0;
}
```
create 100 files with long file names.

This will create too many entries to add to a floppy's root directory.

Without this PR, Bochs will crash on startup leaving the `vvfat` directory as read only.

This PR will stop adding files and continue as normal allowing Bochs to run successfully, but only with the files that fit in the directory, in this particular case, the first 74 files.